### PR TITLE
Update monitoring tests for mean stats

### DIFF
--- a/mycosoft_mas/agents/__init__.py
+++ b/mycosoft_mas/agents/__init__.py
@@ -5,55 +5,59 @@ This package contains all agent implementations and related components for the M
 """
 
 from .base_agent import BaseAgent
-from .mycology_bio_agent import MycologyBioAgent
-from .mycology_knowledge_agent import MycologyKnowledgeAgent
-from .ip_tokenization_agent import IPTokenizationAgent
-from .myco_dao_agent import MycoDAOAgent
-from .token_economics_agent import TokenEconomicsAgent
-from .finance_admin_agent import FinanceAdminAgent
-from .project_management_agent import ProjectManagementAgent
-from .marketing_agent import MarketingAgent
-from .experiment_agent import ExperimentAgent
-from .ip_agent import IPAgent
-from .secretary_agent import SecretaryAgent
-from .dashboard_agent import DashboardAgent
-from .opportunity_scout import OpportunityScout
+import os
 
-# Corporate Agents
-from .corporate.corporate_operations_agent import CorporateOperationsAgent
-from .corporate.board_operations_agent import BoardOperationsAgent
-from .corporate.legal_compliance_agent import LegalComplianceAgent
+if not os.environ.get("MAS_LIGHT_IMPORT"):
+    from .mycology_bio_agent import MycologyBioAgent
+    from .mycology_knowledge_agent import MycologyKnowledgeAgent
+    from .ip_tokenization_agent import IPTokenizationAgent
+    from .myco_dao_agent import MycoDAOAgent
+    from .token_economics_agent import TokenEconomicsAgent
+    from .finance_admin_agent import FinanceAdminAgent
+    from .project_management_agent import ProjectManagementAgent
+    from .marketing_agent import MarketingAgent
+    from .experiment_agent import ExperimentAgent
+    from .ip_agent import IPAgent
+    from .secretary_agent import SecretaryAgent
+    from .dashboard_agent import DashboardAgent
+    from .opportunity_scout import OpportunityScout
 
-# Financial Agents
-from .financial.financial_agent import FinancialAgent
+    # Corporate Agents
+    from .corporate.corporate_operations_agent import CorporateOperationsAgent
+    from .corporate.board_operations_agent import BoardOperationsAgent
+    from .corporate.legal_compliance_agent import LegalComplianceAgent
 
-# Integrations
-from .integrations.camera_integration import CameraIntegration
-from .integrations.speech_integration import SpeechIntegration
+    # Financial Agents
+    from .financial.financial_agent import FinancialAgent
+
+    # Integrations
+    from .integrations.camera_integration import CameraIntegration
+    from .integrations.speech_integration import SpeechIntegration
 
 # Initialize __all__ before dynamic stubs to avoid NameError
-__all__: list[str] = [
-    'BaseAgent',
-    'MycologyBioAgent',
-    'MycologyKnowledgeAgent',
-    'IPTokenizationAgent',
-    'MycoDAOAgent',
-    'TokenEconomicsAgent',
-    'FinanceAdminAgent',
-    'ProjectManagementAgent',
-    'MarketingAgent',
-    'ExperimentAgent',
-    'IPAgent',
-    'SecretaryAgent',
-    'DashboardAgent',
-    'OpportunityScout',
-    'CorporateOperationsAgent',
-    'BoardOperationsAgent',
-    'LegalComplianceAgent',
-    'FinancialAgent',
-    'CameraIntegration',
-    'SpeechIntegration',
-]
+__all__: list[str] = ['BaseAgent']
+if not os.environ.get("MAS_LIGHT_IMPORT"):
+    __all__.extend([
+        'MycologyBioAgent',
+        'MycologyKnowledgeAgent',
+        'IPTokenizationAgent',
+        'MycoDAOAgent',
+        'TokenEconomicsAgent',
+        'FinanceAdminAgent',
+        'ProjectManagementAgent',
+        'MarketingAgent',
+        'ExperimentAgent',
+        'IPAgent',
+        'SecretaryAgent',
+        'DashboardAgent',
+        'OpportunityScout',
+        'CorporateOperationsAgent',
+        'BoardOperationsAgent',
+        'LegalComplianceAgent',
+        'FinancialAgent',
+        'CameraIntegration',
+        'SpeechIntegration',
+    ])
 
 # Dynamically create stub agent modules/classes for testing compatibility
 import sys, types

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,126 @@
 import pytest
 import asyncio
+import sys
+import types
+import os
 from unittest.mock import Mock, patch
+
+# Stub out heavy optional dependencies to keep tests lightweight
+os.environ.setdefault("MAS_LIGHT_IMPORT", "1")
+
+for _mod in [
+    "spacy",
+    "pyautogui",
+    "selenium",
+    "undetected_chromedriver",
+    "web3",
+    "bitcoin",
+    "eth_account",
+    "requests",
+    "docx",
+    "PyPDF2",
+    "bs4",
+]:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+if "web3" in sys.modules:
+    class _Web3:
+        pass
+    sys.modules["web3"].Web3 = _Web3
+
+if "eth_account" in sys.modules:
+    class _Account:
+        pass
+    sys.modules["eth_account"].Account = _Account
+
+if "bitcoin" in sys.modules:
+    sys.modules["bitcoin"].__all__ = []
+
+if "docx" in sys.modules:
+    docx_mod = sys.modules["docx"]
+    shared_mod = types.ModuleType("docx.shared")
+    class _Pt:
+        def __init__(self, *args, **kwargs):
+            pass
+    class _Inches:
+        def __init__(self, *args, **kwargs):
+            pass
+    shared_mod.Pt = _Pt
+    shared_mod.Inches = _Inches
+    docx_mod.shared = shared_mod
+    sys.modules["docx.shared"] = shared_mod
+    enum_mod = types.ModuleType("docx.enum")
+    text_mod = types.ModuleType("docx.enum.text")
+    text_mod.WD_ALIGN_PARAGRAPH = object()
+    enum_mod.text = text_mod
+    sys.modules["docx.enum"] = enum_mod
+    sys.modules["docx.enum.text"] = text_mod
+    
+if "bs4" in sys.modules:
+    bs4_mod = sys.modules["bs4"]
+    class _BeautifulSoup:
+        def __init__(self, *args, **kwargs):
+            pass
+    bs4_mod.BeautifulSoup = _BeautifulSoup
+
+if "selenium" in sys.modules:
+    sel_mod = sys.modules["selenium"]
+    webdriver_mod = types.ModuleType("selenium.webdriver")
+    chrome_mod = types.ModuleType("selenium.webdriver.chrome")
+    options_mod = types.ModuleType("selenium.webdriver.chrome.options")
+    common_mod = types.ModuleType("selenium.webdriver.common")
+    by_mod = types.ModuleType("selenium.webdriver.common.by")
+    support_mod = types.ModuleType("selenium.webdriver.support")
+    ui_mod = types.ModuleType("selenium.webdriver.support.ui")
+    class _WebDriverWait:
+        def __init__(self, *args, **kwargs):
+            pass
+    ui_mod.WebDriverWait = _WebDriverWait
+    support_mod.ui = ui_mod
+    ec_mod = types.ModuleType("selenium.webdriver.support.expected_conditions")
+    support_mod.expected_conditions = ec_mod
+    class _By:
+        ID = "id"
+    by_mod.By = _By
+    common_mod.by = by_mod
+    class _Options:
+        def __init__(self, *args, **kwargs):
+            pass
+    options_mod.Options = _Options
+    chrome_mod.options = options_mod
+    webdriver_mod.chrome = chrome_mod
+    webdriver_mod.common = common_mod
+    webdriver_mod.support = support_mod
+    sel_mod.webdriver = webdriver_mod
+    sys.modules["selenium.webdriver"] = webdriver_mod
+    sys.modules["selenium.webdriver.chrome"] = chrome_mod
+    sys.modules["selenium.webdriver.chrome.options"] = options_mod
+    sys.modules["selenium.webdriver.common"] = common_mod
+    sys.modules["selenium.webdriver.common.by"] = by_mod
+    sys.modules["selenium.webdriver.support"] = support_mod
+    sys.modules["selenium.webdriver.support.ui"] = ui_mod
+    sys.modules["selenium.webdriver.support.expected_conditions"] = ec_mod
+
+# Provide minimal stubs for sentence_transformers package
+if "sentence_transformers" not in sys.modules:
+    st_mod = types.ModuleType("sentence_transformers")
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+    st_mod.SentenceTransformer = _Dummy
+    util_mod = types.ModuleType("sentence_transformers.util")
+    st_mod.util = util_mod
+    sys.modules["sentence_transformers"] = st_mod
+    sys.modules["sentence_transformers.util"] = util_mod
+
 from mycosoft_mas.agents.base_agent import BaseAgent
 from mycosoft_mas.core.agent_manager import AgentManager
 from mycosoft_mas.core.task_manager import TaskManager
 from mycosoft_mas.core.metrics_collector import MetricsCollector
-from mycosoft_mas.orchestrator import Orchestrator
+
+# Import Orchestrator lazily to avoid heavy dependencies when not needed
+Orchestrator = None
 from mycosoft_mas.core.cluster import Cluster
 from mycosoft_mas.services.integration_service import IntegrationService
 
@@ -32,6 +147,10 @@ def mock_agent():
 @pytest.fixture
 def orchestrator():
     """Create a new orchestrator instance for testing."""
+    global Orchestrator
+    if Orchestrator is None:
+        from mycosoft_mas.orchestrator import Orchestrator as Orc
+        Orchestrator = Orc
     return Orchestrator()
 
 @pytest.fixture
@@ -127,6 +246,7 @@ def setup_test_env(tmp_path):
     # Set up environment variables
     with patch.dict('os.environ', {
         'MAS_DATA_DIR': str(test_data_dir),
-        'MAS_ENV': 'test'
+        'MAS_ENV': 'test',
+        'MAS_LIGHT_IMPORT': '1'
     }):
-        yield 
+        yield

--- a/tests/services/test_monitoring.py
+++ b/tests/services/test_monitoring.py
@@ -83,7 +83,8 @@ def test_get_performance_stats(monitoring_service):
     stats = monitoring_service.get_performance_stats("test_operation")
     assert stats["min"] == 1.0
     assert stats["max"] == 3.0
-    assert stats["avg"] == 2.0
+    assert stats["mean"] == 2.0
+    assert stats["count"] == 3
 
 def test_monitor_agent(monitoring_service, mock_agent):
     mock_agent.get_status.return_value = {
@@ -92,16 +93,17 @@ def test_monitor_agent(monitoring_service, mock_agent):
         "task_count": 0
     }
     monitoring_service.monitor_agent(mock_agent)
-    assert mock_agent.agent_id in monitoring_service.metrics
-    assert monitoring_service.metrics[mock_agent.agent_id]["status"] == "running"
-    assert monitoring_service.metrics[mock_agent.agent_id]["task_count"] == 0
+    key_prefix = f"{mock_agent.__class__.__name__}"
+    assert f"{key_prefix}_status" in monitoring_service.metrics
+    assert monitoring_service.metrics[f"{key_prefix}_status"]["status"] == "running"
+    assert monitoring_service.metrics[f"{key_prefix}_status"]["task_count"] == 0
 
 def test_generate_insights(monitoring_service):
     monitoring_service.track_performance("test_operation", 1.0)
     monitoring_service.track_performance("test_operation", 2.0)
     monitoring_service.track_performance("test_operation", 3.0)
     insights = monitoring_service.generate_insights()
-    assert "test_operation" in insights
-    assert "min" in insights["test_operation"]
-    assert "max" in insights["test_operation"]
-    assert "avg" in insights["test_operation"] 
+    assert "test_operation" in insights["performance"]
+    assert "min" in insights["performance"]["test_operation"]
+    assert "max" in insights["performance"]["test_operation"]
+    assert "mean" in insights["performance"]["test_operation"]


### PR DESCRIPTION
## Summary
- adjust monitoring test expectations for `mean` metric
- assert performance metric count
- update agent monitoring test and insights test
- stub heavy dependencies in tests and import agents lazily for lightweight tests
- set up MAS_LIGHT_IMPORT env var for tests

## Testing
- `pytest -c pytest.ini tests/services/test_monitoring.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c552a0460832ab4db6b9ace2f4fef