### PR TITLE
feat: add event ingestion service

### DIFF
--- a/mycosoft_mas/services/event_ingestion_service.py
+++ b/mycosoft_mas/services/event_ingestion_service.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Simple event ingestion service for Mycosoft MAS.
+
+This service ingests events from external systems and stores them in the
+:class:`KnowledgeGraph`. Events must contain at minimum ``id``, ``type`` and
+``data`` fields. An optional ``source`` field creates a relationship from the
+source entity to the event node in the knowledge graph.
+"""
+
+from typing import Any, Dict
+from datetime import datetime
+
+from ..core.knowledge_graph import KnowledgeGraph
+
+
+class EventIngestionService:
+    """Service responsible for processing external events."""
+
+    def __init__(self, knowledge_graph: KnowledgeGraph) -> None:
+        self.knowledge_graph = knowledge_graph
+
+    async def process_event(self, event: Dict[str, Any]) -> None:
+        """Validate and ingest an event into the knowledge graph.
+
+        Parameters
+        ----------
+        event:
+            Dictionary containing the event payload. Must include ``id``,
+            ``type`` and ``data`` keys. Optionally may include ``source`` and
+            ``timestamp``.
+        """
+        required = {"id", "type", "data"}
+        missing = required - event.keys()
+        if missing:
+            raise ValueError(f"Event missing required fields: {', '.join(sorted(missing))}")
+
+        metadata = {
+            "event_type": event["type"],
+            "timestamp": event.get("timestamp", datetime.utcnow().isoformat()),
+            "data": event["data"],
+        }
+
+        # Add event node
+        await self.knowledge_graph.add_agent(event["id"], metadata)
+
+        # Link to source if provided
+        source = event.get("source")
+        if source:
+            if source not in self.knowledge_graph.graph:
+                await self.knowledge_graph.add_agent(source, {"type": "source"})
+            await self.knowledge_graph.add_relationship(source, event["id"], "generated")

--- a/tests/services/test_event_ingestion_service.py
+++ b/tests/services/test_event_ingestion_service.py
@@ -1,0 +1,26 @@
+import pytest
+
+from mycosoft_mas.core.knowledge_graph import KnowledgeGraph
+from mycosoft_mas.services.event_ingestion_service import EventIngestionService
+
+
+@pytest.mark.asyncio
+async def test_process_event_adds_node_and_edge():
+    kg = KnowledgeGraph()
+    await kg.initialize()
+    service = EventIngestionService(kg)
+
+    event = {
+        "id": "event1",
+        "type": "env.v1",
+        "source": "device123",
+        "data": {"temperature": 21.5},
+    }
+
+    await service.process_event(event)
+
+    assert "event1" in kg.graph
+    assert kg.graph.has_edge("device123", "event1")
+    metadata = kg.get_agent_metadata("event1")
+    assert metadata["event_type"] == "env.v1"
+    assert metadata["data"]["temperature"] == 21.5


### PR DESCRIPTION
## Summary
- add an `EventIngestionService` that validates incoming events and stores them in the knowledge graph
- create unit test covering event node and edge creation

## Testing
- `PYTHONPATH=$PWD pytest tests/services/test_event_ingestion_service.py -q` *(fails: ModuleNotFoundError: No module named 'jwt')*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_689654ff215c832ab66667671b0e2712