### PR TITLE
Personaplex multi-agent bridging

### DIFF
--- a/Dockerfile.personaplex-bridge
+++ b/Dockerfile.personaplex-bridge
@@ -1,17 +1,17 @@
-﻿# PersonaPlex Bridge Dockerfile - January 27, 2026
+# PersonaPlex Bridge Dockerfile - January 27, 2026
 FROM python:3.11-slim
 
 WORKDIR /app
 
 RUN pip install --no-cache-dir aiohttp websockets httpx uvicorn fastapi
 
-COPY mycosoft_mas/voice /app/voice
-COPY mycosoft_mas/__init__.py /app/mycosoft_mas/__init__.py
+COPY services/personaplex-local/personaplex_bridge_nvidia.py /app/personaplex_bridge_nvidia.py
 
-ENV PERSONAPLEX_URL=wss://personaplex:8998
+ENV MOSHI_HOST=personaplex
+ENV MOSHI_PORT=8998
 ENV MAS_ORCHESTRATOR_URL=http://mas-orchestrator:8001
-ENV N8N_WEBHOOK_URL=http://n8n:5678/webhook
+ENV MAS_CHAT_PATH=/voice/orchestrator/chat
 
 EXPOSE 8999
 
-CMD ["python", "-m", "uvicorn", "voice.bridge_api:app", "--host", "0.0.0.0", "--port", "8999"]
+CMD ["python", "/app/personaplex_bridge_nvidia.py"]

--- a/services/personaplex-local/personaplex_bridge_nvidia.py
+++ b/services/personaplex-local/personaplex_bridge_nvidia.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 '''
 PersonaPlex NVIDIA Bridge - January 29, 2026
 Proper integration with NVIDIA PersonaPlex server as intended
@@ -12,17 +12,21 @@ This bridge:
 '''
 import asyncio
 import json
+import logging
 import os
+import re
+import time
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
 from uuid import uuid4
-import httpx
+
 import aiohttp
+import httpx
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
-import logging
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("personaplex-bridge")
@@ -41,7 +45,13 @@ app.add_middleware(
 MOSHI_HOST = os.getenv("MOSHI_HOST", "localhost")
 MOSHI_PORT = int(os.getenv("MOSHI_PORT", "8998"))
 MOSHI_WS_URL = f"ws://{MOSHI_HOST}:{MOSHI_PORT}/api/chat"
-MAS_ORCHESTRATOR_URL = os.getenv("MAS_ORCHESTRATOR_URL", "http://192.168.0.188:8001")
+MAS_ORCHESTRATOR_URL = os.getenv("MAS_ORCHESTRATOR_URL", "http://192.168.0.188:8001").rstrip("/")
+MAS_CHAT_PATH = os.getenv("MAS_CHAT_PATH", "/voice/orchestrator/chat")
+MAS_TIMEOUT = float(os.getenv("MAS_TIMEOUT", "15"))
+MAS_MIN_INTERVAL = float(os.getenv("MAS_MIN_INTERVAL", "1.2"))
+ENABLE_MAS_ROUTING = os.getenv("ENABLE_MAS_ROUTING", "1") != "0"
+ENABLE_MOSHI_TEXT_INJECTION = os.getenv("ENABLE_MOSHI_TEXT_INJECTION", "1") != "0"
+TRANSCRIPT_DEDUP_SECONDS = float(os.getenv("TRANSCRIPT_DEDUP_SECONDS", "2.0"))
 
 # MYCA Persona Prompt (as NVIDIA PersonaPlex expects)
 MYCA_PERSONA = '''You are MYCA (Mycosoft Autonomous Cognitive Agent), an AI assistant for Mycosoft.
@@ -63,9 +73,49 @@ class SessionCreate(BaseModel):
     persona: str = "myca"
     voice: str = "myca"
 
-sessions = {}
+@dataclass
+class BridgeSession:
+    session_id: str
+    conversation_id: str
+    persona: str
+    voice: str
+    voice_prompt: str
+    text_prompt: str
+    created_at: str
+    last_moshi_text: Optional[str] = None
+    last_moshi_text_at: float = 0.0
+    last_mas_call_at: float = 0.0
+    last_mas_response: Optional[str] = None
+    last_mas_response_at: float = 0.0
+    pending_confirmation: Optional[str] = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    def to_dict(self) -> dict:
+        return {
+            "session_id": self.session_id,
+            "conversation_id": self.conversation_id,
+            "persona": self.persona,
+            "voice": self.voice,
+            "voice_prompt": self.voice_prompt,
+            "created_at": self.created_at,
+            "pending_confirmation": self.pending_confirmation is not None,
+        }
+
+
+sessions: dict[str, BridgeSession] = {}
 moshi_available = False
 last_check = None
+
+ACTION_PATTERNS = [
+    r"\b(turn on|turn off|start|stop|restart|reboot|shutdown)\b",
+    r"\b(deploy|rebuild|clear|purge|reset|delete|remove)\b",
+    r"\b(enable|disable|open|close|connect|disconnect)\b",
+]
+QUERY_PATTERNS = [
+    r"\b(status|health|check|list|show|how many|what is|what are)\b",
+]
+CONFIRM_PATTERNS = [r"\b(yes|yeah|confirm|proceed|do it|go ahead)\b"]
+CANCEL_PATTERNS = [r"\b(no|cancel|abort|never mind)\b"]
 
 async def check_moshi_health():
     global moshi_available, last_check
@@ -83,10 +133,90 @@ async def check_moshi_health():
     last_check = datetime.now(timezone.utc).isoformat()
     return False
 
+def normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+def match_any(patterns: list[str], text: str) -> bool:
+    return any(re.search(p, text, re.IGNORECASE) for p in patterns)
+
+def classify_intent(text: str) -> dict:
+    normalized = normalize_text(text)
+    if not normalized:
+        return {"type": "empty", "requires_tool": False, "requires_confirmation": False}
+    if match_any(CONFIRM_PATTERNS, normalized):
+        return {"type": "confirm", "requires_tool": True, "requires_confirmation": False}
+    if match_any(CANCEL_PATTERNS, normalized):
+        return {"type": "cancel", "requires_tool": False, "requires_confirmation": False}
+    if match_any(ACTION_PATTERNS, normalized):
+        needs_confirmation = any(k in normalized.lower() for k in ["delete", "remove", "shutdown", "purge", "reset", "clear"])
+        return {"type": "action", "requires_tool": True, "requires_confirmation": needs_confirmation}
+    if match_any(QUERY_PATTERNS, normalized):
+        return {"type": "query", "requires_tool": True, "requires_confirmation": False}
+    return {"type": "chitchat", "requires_tool": False, "requires_confirmation": False}
+
+async def get_http_client() -> httpx.AsyncClient:
+    client = getattr(app.state, "http", None)
+    if client is None:
+        client = httpx.AsyncClient(timeout=MAS_TIMEOUT)
+        app.state.http = client
+    return client
+
+def extract_response_text(payload: object) -> Optional[str]:
+    if isinstance(payload, dict):
+        for key in ("response_text", "response", "text", "message", "answer"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    if isinstance(payload, list) and payload:
+        first = payload[0]
+        if isinstance(first, str) and first.strip():
+            return first.strip()
+        if isinstance(first, dict):
+            for key in ("response_text", "response", "text", "message", "answer"):
+                value = first.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+    return None
+
+async def call_mas(session: BridgeSession, message: str) -> tuple[str, dict]:
+    if not MAS_ORCHESTRATOR_URL:
+        raise RuntimeError("MAS_ORCHESTRATOR_URL is not configured")
+    client = await get_http_client()
+    payload = {
+        "message": message,
+        "conversation_id": session.conversation_id,
+        "session_id": session.session_id,
+        "source": "personaplex-nvidia-bridge",
+        "persona": session.persona,
+        "voice_prompt": session.voice_prompt,
+    }
+    response = await client.post(f"{MAS_ORCHESTRATOR_URL}{MAS_CHAT_PATH}", json=payload)
+    response.raise_for_status()
+    data = response.json()
+    response_text = extract_response_text(data)
+    if not response_text:
+        raise RuntimeError("MAS response missing response_text")
+    return response_text, data
+
+async def send_moshi_text(moshi_ws: aiohttp.ClientWebSocketResponse, text: str) -> None:
+    if not ENABLE_MOSHI_TEXT_INJECTION:
+        return
+    message = normalize_text(text)
+    if not message:
+        return
+    await moshi_ws.send_bytes(b"\x02" + message.encode("utf-8"))
+
 @app.on_event("startup")
 async def startup():
     await check_moshi_health()
     asyncio.create_task(periodic_check())
+
+@app.on_event("shutdown")
+async def shutdown():
+    client = getattr(app.state, "http", None)
+    if client:
+        await client.aclose()
+        app.state.http = None
 
 async def periodic_check():
     while True:
@@ -102,6 +232,8 @@ async def health():
         "moshi_url": f"http://{MOSHI_HOST}:{MOSHI_PORT}",
         "moshi_ws_url": MOSHI_WS_URL,
         "mas_orchestrator": MAS_ORCHESTRATOR_URL,
+        "mas_routing_enabled": ENABLE_MAS_ROUTING,
+        "moshi_text_injection": ENABLE_MOSHI_TEXT_INJECTION,
         "timestamp": last_check or datetime.now(timezone.utc).isoformat()
     }
 
@@ -112,15 +244,15 @@ async def create_session(req: SessionCreate):
     voice_prompt = VOICE_PROMPTS.get(req.voice, VOICE_PROMPTS["default"])
     text_prompt = MYCA_PERSONA if req.persona == "myca" else ""
     
-    sessions[sid] = {
-        "conversation_id": cid,
-        "mode": req.mode,
-        "persona": req.persona,
-        "voice": req.voice,
-        "voice_prompt": voice_prompt,
-        "text_prompt": text_prompt,
-        "created_at": datetime.now(timezone.utc).isoformat(),
-    }
+    sessions[sid] = BridgeSession(
+        session_id=sid,
+        conversation_id=cid,
+        persona=req.persona,
+        voice=req.voice,
+        voice_prompt=voice_prompt,
+        text_prompt=text_prompt,
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )
     
     return {
         "session_id": sid,
@@ -130,12 +262,12 @@ async def create_session(req: SessionCreate):
         "voice_prompt": voice_prompt,
         "ws_url": f"ws://localhost:8999/ws/{sid}",
         "direct_moshi_url": f"http://{MOSHI_HOST}:{MOSHI_PORT}",
-        "created_at": sessions[sid]["created_at"]
+        "created_at": sessions[sid].created_at
     }
 
 @app.get("/sessions")
 async def list_sessions():
-    return {"sessions": [{"session_id": k, **v} for k, v in sessions.items()], "count": len(sessions)}
+    return {"sessions": [session.to_dict() for session in sessions.values()], "count": len(sessions)}
 
 @app.delete("/session/{session_id}")
 async def end_session(session_id: str):
@@ -158,12 +290,23 @@ async def list_voices():
 @app.websocket("/ws/{session_id}")
 async def websocket_bridge(websocket: WebSocket, session_id: str):
     await websocket.accept()
-    session = sessions.get(session_id, {"text_prompt": MYCA_PERSONA, "voice_prompt": "NATF2.pt"})
+    session = sessions.get(session_id)
+    if session is None:
+        session = BridgeSession(
+            session_id=session_id,
+            conversation_id=str(uuid4()),
+            persona="myca",
+            voice="myca",
+            voice_prompt=VOICE_PROMPTS["default"],
+            text_prompt=MYCA_PERSONA,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        sessions[session_id] = session
     
     import urllib.parse
     params = urllib.parse.urlencode({
-        "text_prompt": session.get("text_prompt", MYCA_PERSONA),
-        "voice_prompt": session.get("voice_prompt", "NATF2.pt"),
+        "text_prompt": session.text_prompt or MYCA_PERSONA,
+        "voice_prompt": session.voice_prompt or "NATF2.pt",
         "audio_temperature": "0.8",
         "text_temperature": "0.8",
         "text_topk": "25",
@@ -195,7 +338,10 @@ async def websocket_bridge(websocket: WebSocket, session_id: str):
                                         await websocket.send_bytes(payload)
                                     elif kind == 2:
                                         text = payload.decode("utf-8")
+                                        normalized = normalize_text(text)
                                         await websocket.send_json({"type": "text", "text": text})
+                                        if ENABLE_MAS_ROUTING and normalized:
+                                            await handle_moshi_text(normalized, session, moshi_ws, websocket)
                             elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
                                 break
                     except Exception as e:
@@ -207,6 +353,8 @@ async def websocket_bridge(websocket: WebSocket, session_id: str):
                             data = await websocket.receive()
                             if "bytes" in data:
                                 await moshi_ws.send_bytes(b'\x01' + data["bytes"])
+                            elif "text" in data:
+                                await handle_browser_text(data["text"], session, moshi_ws, websocket)
                     except WebSocketDisconnect:
                         logger.info(f"Browser disconnected: {session_id}")
                     except Exception as e:
@@ -216,6 +364,100 @@ async def websocket_bridge(websocket: WebSocket, session_id: str):
     except Exception as e:
         logger.error(f"WebSocket bridge error: {e}")
         await websocket.send_json({"type": "error", "message": str(e)})
+
+async def handle_browser_text(raw_text: str, session: BridgeSession, moshi_ws: aiohttp.ClientWebSocketResponse, websocket: WebSocket) -> None:
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
+        payload = {"type": "user_text", "text": raw_text}
+
+    if not isinstance(payload, dict):
+        return
+
+    message_type = payload.get("type", "user_text")
+    text = normalize_text(payload.get("text", ""))
+    if not text:
+        return
+
+    if message_type in ("user_text", "text_input"):
+        await route_to_mas(text, session, moshi_ws, websocket, source="browser")
+        return
+
+    if message_type == "confirm" and session.pending_confirmation:
+        await route_to_mas(session.pending_confirmation, session, moshi_ws, websocket, source="confirmation")
+        session.pending_confirmation = None
+        return
+
+async def handle_moshi_text(text: str, session: BridgeSession, moshi_ws: aiohttp.ClientWebSocketResponse, websocket: WebSocket) -> None:
+    normalized = normalize_text(text)
+    if not normalized:
+        return
+
+    now = time.monotonic()
+    async with session.lock:
+        if session.last_moshi_text == normalized and now - session.last_moshi_text_at < TRANSCRIPT_DEDUP_SECONDS:
+            return
+        if session.last_mas_response and normalized == session.last_mas_response and now - session.last_mas_response_at < TRANSCRIPT_DEDUP_SECONDS:
+            return
+        session.last_moshi_text = normalized
+        session.last_moshi_text_at = now
+
+    intent = classify_intent(normalized)
+    if intent["type"] == "cancel":
+        session.pending_confirmation = None
+        await websocket.send_json({"type": "confirmation_cancelled", "text": normalized, "session_id": session.session_id})
+        return
+
+    if intent["type"] == "confirm" and session.pending_confirmation:
+        await route_to_mas(session.pending_confirmation, session, moshi_ws, websocket, source="confirmation")
+        session.pending_confirmation = None
+        return
+
+    if intent["requires_confirmation"]:
+        session.pending_confirmation = normalized
+        confirmation_prompt = f"Confirmation required for: {normalized}"
+        session.last_mas_response = normalize_text(confirmation_prompt)
+        session.last_mas_response_at = time.monotonic()
+        await websocket.send_json({
+            "type": "confirmation_required",
+            "text": normalized,
+            "session_id": session.session_id,
+        })
+        await send_moshi_text(moshi_ws, confirmation_prompt)
+        return
+
+    if intent["requires_tool"]:
+        await route_to_mas(normalized, session, moshi_ws, websocket, source="moshi")
+
+async def route_to_mas(text: str, session: BridgeSession, moshi_ws: aiohttp.ClientWebSocketResponse, websocket: WebSocket, source: str) -> None:
+    now = time.monotonic()
+    async with session.lock:
+        if now - session.last_mas_call_at < MAS_MIN_INTERVAL:
+            return
+        session.last_mas_call_at = now
+
+    try:
+        response_text, data = await call_mas(session, text)
+        session.last_mas_response = normalize_text(response_text)
+        session.last_mas_response_at = time.monotonic()
+        await websocket.send_json({
+            "type": "mas_result",
+            "text": response_text,
+            "source_text": text,
+            "session_id": session.session_id,
+            "meta": {
+                "source": source,
+                "conversation_id": session.conversation_id,
+            },
+        })
+        await send_moshi_text(moshi_ws, response_text)
+    except Exception as exc:
+        await websocket.send_json({
+            "type": "mas_error",
+            "message": str(exc),
+            "source_text": text,
+            "session_id": session.session_id,
+        })
 
 @app.get("/")
 async def redirect_to_moshi():


### PR DESCRIPTION
Retrofit the NVIDIA PersonaPlex bridge to integrate with the Multi-Agent System (MAS) for full-duplex speech-to-speech, replacing mock data with real n8n calls and fixing the Docker bridge setup.

This PR implements the requested "NVIDIA full duplex + massively real and details and MAS integrated retrofit." The `personaplex_bridge_nvidia.py` now routes actionable text from Moshi to the MAS, injecting the MAS response back into Moshi for vocalization, and includes features like confirmation gating and deduplication. MAS voice endpoints are updated to call n8n for real responses, ensuring no mock data is returned, and the Dockerfile for the bridge is corrected to run the NVIDIA bridge directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e4fe663-cdad-4a6a-ba50-f66de28b9a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e4fe663-cdad-4a6a-ba50-f66de28b9a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Integrate the NVIDIA PersonaPlex bridge with the Multi-Agent System for full-duplex speech-to-speech, wiring real MAS/n8n calls and fixing the bridge Docker setup.

New Features:
- Enable routing of actionable text from Moshi through the Multi-Agent System and back for spoken responses in the NVIDIA PersonaPlex bridge.

Enhancements:
- Replace mock responses with real n8n-backed MAS voice endpoints for production-style behavior.
- Adjust the bridge Dockerfile to run the NVIDIA PersonaPlex bridge entrypoint correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces previously local/mock voice responses with external `n8n` workflow calls and adds new routing/confirmation logic in the PersonaPlex WebSocket bridge, which can impact runtime behavior and failure modes if env/config or payload expectations differ.
> 
> **Overview**
> Routes voice/chat requests through real `n8n` workflows instead of returning mock responses: both `myca_main.py` and `orchestrator_service.py` now validate input, require `N8N_WEBHOOK_URL`/`N8N_URL`, trigger `N8N_VOICE_WEBHOOK`, and parse `response_text` from the workflow result (with 4xx/5xx-style error handling).
> 
> Retrofits `personaplex_bridge_nvidia.py` to do full-duplex MAS integration: sessions are tracked via a `BridgeSession` dataclass, Moshi transcript text can be intent-classified (query/action/confirm/cancel), gated behind confirmations for destructive intents, deduplicated/rate-limited, and forwarded to MAS with results injected back into Moshi for vocalization.
> 
> Fixes the bridge container entrypoint by updating `Dockerfile.personaplex-bridge` to copy/run `personaplex_bridge_nvidia.py` directly and switches env config from `PERSONAPLEX_URL` to `MOSHI_HOST`/`MOSHI_PORT` plus `MAS_CHAT_PATH`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52dc0bd927b19f8af06710cc7b9d769f90969765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->