### PR TITLE
fix(orchestration): wire MAS agent lifecycle, heartbeat, dashboard, and task intake

### DIFF
--- a/mycosoft_mas/agents/v2/data_agents.py
+++ b/mycosoft_mas/agents/v2/data_agents.py
@@ -16,29 +16,34 @@ from mycosoft_mas.runtime import AgentTask, AgentCategory
 class MindexAgent(BaseAgentV2):
     """
     MINDEX Agent - Database Operations
-    
+
+    Updated March 19, 2026 — Real MINDEX integration via mindex_client.
+
     Responsibilities:
-    - Database queries
+    - Database queries via MINDEX API (192.168.0.189:8000)
     - Data freshness monitoring
     - ETL coordination
+    - Species/observation queries
     """
-    
+
+    MINDEX_API_URL = os.getenv("MINDEX_API_URL", "http://192.168.0.189:8000")
+
     @property
     def agent_type(self) -> str:
         return "mindex"
-    
+
     @property
     def category(self) -> str:
         return AgentCategory.DATA.value
-    
+
     @property
     def display_name(self) -> str:
         return "MINDEX Agent"
-    
+
     @property
     def description(self) -> str:
         return "Manages MINDEX database operations"
-    
+
     def get_capabilities(self) -> List[str]:
         return [
             "query_species",
@@ -46,29 +51,108 @@ class MindexAgent(BaseAgentV2):
             "data_freshness",
             "etl_status",
             "backup_status",
+            "search",
         ]
-    
+
     async def on_start(self):
         self.register_handler("query", self._handle_query)
         self.register_handler("etl_status", self._handle_etl_status)
-    
+        self.register_handler("search", self._handle_search)
+        self.register_handler("health", self._handle_health)
+
     async def _handle_query(self, task: AgentTask) -> Dict[str, Any]:
-        """Execute MINDEX query"""
-        query_type = task.payload.get("query_type")
+        """Execute MINDEX query via the real MINDEX API."""
+        query_type = task.payload.get("query_type", "species")
         filters = task.payload.get("filters", {})
-        return {
-            "query_type": query_type,
-            "results": [],
-            "total": 0,
+        limit = task.payload.get("limit", 50)
+
+        endpoint_map = {
+            "species": "/api/mindex/taxa",
+            "observations": "/api/mindex/observations",
+            "telemetry": "/api/mindex/telemetry/latest",
+            "compounds": "/api/mindex/compounds",
         }
-    
+        endpoint = endpoint_map.get(query_type, f"/api/mindex/{query_type}")
+
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                params = {**filters, "limit": limit}
+                response = await client.get(f"{self.MINDEX_API_URL}{endpoint}", params=params)
+                response.raise_for_status()
+                data = response.json()
+
+                results = data.get("results", data.get("data", data.get("items", [])))
+                total = data.get("total", len(results))
+
+                return {
+                    "query_type": query_type,
+                    "results": results,
+                    "total": total,
+                    "source": "mindex_api",
+                }
+        except httpx.HTTPError as e:
+            return {
+                "query_type": query_type,
+                "results": [],
+                "total": 0,
+                "error": str(e),
+                "source": "mindex_api",
+            }
+
     async def _handle_etl_status(self, task: AgentTask) -> Dict[str, Any]:
-        """Get ETL pipeline status"""
-        return {
-            "last_run": None,
-            "status": "idle",
-            "records_processed": 0,
-        }
+        """Get ETL pipeline status from MINDEX."""
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(f"{self.MINDEX_API_URL}/api/mindex/health")
+                response.raise_for_status()
+                health = response.json()
+
+                return {
+                    "status": health.get("status", "unknown"),
+                    "last_run": health.get("last_etl_run"),
+                    "records_processed": health.get("total_records", 0),
+                    "source": "mindex_api",
+                }
+        except httpx.HTTPError as e:
+            return {
+                "status": "unreachable",
+                "error": str(e),
+                "last_run": None,
+                "records_processed": 0,
+            }
+
+    async def _handle_search(self, task: AgentTask) -> Dict[str, Any]:
+        """Search MINDEX via the search API."""
+        query = task.payload.get("query", "")
+        search_type = task.payload.get("search_type", "keyword")
+        limit = task.payload.get("limit", 20)
+
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                response = await client.post(
+                    f"{self.MINDEX_API_URL}/api/mindex/search",
+                    json={"query": query, "search_type": search_type, "limit": limit},
+                )
+                response.raise_for_status()
+                data = response.json()
+                return {
+                    "query": query,
+                    "results": data.get("results", []),
+                    "total": data.get("total", 0),
+                    "source": "mindex_search",
+                }
+        except httpx.HTTPError as e:
+            return {"query": query, "results": [], "total": 0, "error": str(e)}
+
+    async def _handle_health(self, task: AgentTask) -> Dict[str, Any]:
+        """Check MINDEX API health."""
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(f"{self.MINDEX_API_URL}/health")
+                response.raise_for_status()
+                return {"status": "healthy", "details": response.json()}
+        except Exception as e:
+            return {"status": "unhealthy", "error": str(e)}
 
 
 class NLMAgent(BaseAgentV2):

--- a/mycosoft_mas/core/agent_heartbeat_service.py
+++ b/mycosoft_mas/core/agent_heartbeat_service.py
@@ -1,0 +1,272 @@
+"""
+Agent Heartbeat Service — March 19, 2026
+
+The missing bridge between the MAS agent runtime and the visibility layer.
+
+Problem: Agents run in the runner, topology viewer listens to Redis agents:status,
+but nothing publishes heartbeats. Dashboard shows zeros. Morgan sees nothing.
+
+Solution: This service runs as a background task, polls agent runner state every
+15 seconds, and publishes real status to Redis channels that the topology viewer,
+dashboard, and WebSocket streams already subscribe to.
+
+NO MOCK DATA — All metrics come from the real agent runner and system health.
+"""
+
+import asyncio
+import logging
+import os
+import time
+from collections import defaultdict
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import psutil
+
+logger = logging.getLogger(__name__)
+
+# Heartbeat interval in seconds
+HEARTBEAT_INTERVAL = int(os.getenv("HEARTBEAT_INTERVAL", "15"))
+
+
+class AgentMetrics:
+    """Tracks per-agent runtime metrics across cycles."""
+
+    def __init__(self):
+        self.tasks_completed: int = 0
+        self.tasks_failed: int = 0
+        self.insights_generated: int = 0
+        self.knowledge_added: int = 0
+        self.last_cycle_time: Optional[str] = None
+        self.last_cycle_duration_ms: float = 0
+        self.consecutive_errors: int = 0
+        self.status: str = "idle"
+        self.last_error: Optional[str] = None
+        self.first_seen: str = datetime.now(timezone.utc).isoformat()
+        self.cycle_count: int = 0
+
+    def record_cycle(self, cycle_data: Dict[str, Any]):
+        """Record a completed cycle."""
+        self.cycle_count += 1
+        self.tasks_completed += cycle_data.get("tasks_processed", 0)
+        self.insights_generated += cycle_data.get("insights_generated", 0)
+        self.knowledge_added += cycle_data.get("knowledge_added", 0)
+        self.last_cycle_time = datetime.now(timezone.utc).isoformat()
+
+        if cycle_data.get("status") == "error":
+            self.tasks_failed += 1
+            self.consecutive_errors += 1
+            self.status = "error" if self.consecutive_errors >= 3 else "degraded"
+            errors = cycle_data.get("errors", [])
+            self.last_error = errors[-1] if errors else "Unknown error"
+        else:
+            self.consecutive_errors = 0
+            self.status = "active"
+            self.last_error = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tasks_completed": self.tasks_completed,
+            "tasks_failed": self.tasks_failed,
+            "insights_generated": self.insights_generated,
+            "knowledge_added": self.knowledge_added,
+            "last_cycle_time": self.last_cycle_time,
+            "last_cycle_duration_ms": self.last_cycle_duration_ms,
+            "consecutive_errors": self.consecutive_errors,
+            "status": self.status,
+            "last_error": self.last_error,
+            "first_seen": self.first_seen,
+            "cycle_count": self.cycle_count,
+        }
+
+
+class AgentHeartbeatService:
+    """
+    Bridges the agent runner to Redis pub/sub channels.
+
+    Publishes to:
+    - agents:status — per-agent heartbeats (consumed by topology_stream.py)
+    - system:health — aggregate system metrics (consumed by system_health_ws.py)
+    - tasks:progress — task completion events (consumed by task_progress_ws.py)
+    """
+
+    def __init__(self):
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+        self._agent_metrics: Dict[str, AgentMetrics] = defaultdict(AgentMetrics)
+        self._start_time = time.time()
+        self._total_heartbeats = 0
+        self._redis_connected = False
+        self._last_cycle_snapshot: Dict[str, Any] = {}
+
+    @property
+    def agent_metrics(self) -> Dict[str, AgentMetrics]:
+        """Expose metrics for dashboard/orchestrator API to read."""
+        return self._agent_metrics
+
+    def get_system_summary(self) -> Dict[str, Any]:
+        """Get aggregate system metrics — used by dashboard router."""
+        total_tasks = sum(m.tasks_completed for m in self._agent_metrics.values())
+        total_errors = sum(m.tasks_failed for m in self._agent_metrics.values())
+        total_insights = sum(m.insights_generated for m in self._agent_metrics.values())
+        active_count = sum(1 for m in self._agent_metrics.values() if m.status == "active")
+        degraded_count = sum(1 for m in self._agent_metrics.values() if m.status == "degraded")
+        error_count = sum(1 for m in self._agent_metrics.values() if m.status == "error")
+
+        try:
+            cpu_usage = psutil.cpu_percent(interval=None)
+            memory = psutil.virtual_memory()
+            memory_usage = memory.percent
+        except Exception:
+            cpu_usage = 0
+            memory_usage = 0
+
+        uptime_seconds = int(time.time() - self._start_time)
+
+        return {
+            "total_agents": len(self._agent_metrics),
+            "active_agents": active_count,
+            "degraded_agents": degraded_count,
+            "error_agents": error_count,
+            "total_tasks_completed": total_tasks,
+            "total_errors": total_errors,
+            "total_insights": total_insights,
+            "cpu_usage": cpu_usage,
+            "memory_usage": memory_usage,
+            "uptime_seconds": uptime_seconds,
+            "heartbeat_count": self._total_heartbeats,
+            "redis_connected": self._redis_connected,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+    async def start(self):
+        """Start the heartbeat background loop."""
+        if self._running:
+            logger.warning("Heartbeat service already running")
+            return
+
+        self._running = True
+        self._start_time = time.time()
+        self._task = asyncio.create_task(self._heartbeat_loop())
+        logger.info(f"Agent heartbeat service started (interval={HEARTBEAT_INTERVAL}s)")
+
+    async def stop(self):
+        """Stop the heartbeat service."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("Agent heartbeat service stopped")
+
+    async def _heartbeat_loop(self):
+        """Main heartbeat loop — polls runner, publishes to Redis."""
+        # Initial delay to let the runner start
+        await asyncio.sleep(5)
+
+        while self._running:
+            try:
+                await self._collect_and_publish()
+                self._total_heartbeats += 1
+            except Exception as e:
+                logger.error(f"Heartbeat cycle error: {e}")
+
+            await asyncio.sleep(HEARTBEAT_INTERVAL)
+
+    async def _collect_and_publish(self):
+        """Collect agent status from runner and publish to Redis."""
+        from mycosoft_mas.core.agent_runner import get_agent_runner
+
+        runner = get_agent_runner()
+        runner_status = await runner.get_status()
+
+        # Update metrics from runner's recent cycles
+        for cycle_data in runner_status.get("recent_cycles", []):
+            agent_id = cycle_data.get("agent_id", "unknown")
+            if agent_id not in self._last_cycle_snapshot or \
+               self._last_cycle_snapshot.get(agent_id) != cycle_data.get("cycle_id"):
+                self._agent_metrics[agent_id].record_cycle(cycle_data)
+                self._last_cycle_snapshot[agent_id] = cycle_data.get("cycle_id")
+
+        # Ensure all runner agents have metrics entries
+        for agent in runner._agents:
+            agent_id = getattr(agent, "agent_id", getattr(agent, "name", str(id(agent))))
+            if agent_id not in self._agent_metrics:
+                self._agent_metrics[agent_id] = AgentMetrics()
+                self._agent_metrics[agent_id].status = "idle"
+
+        # Publish to Redis
+        try:
+            from mycosoft_mas.realtime.redis_pubsub import (
+                get_client,
+                publish_agent_status,
+                Channel,
+            )
+
+            client = await get_client()
+            self._redis_connected = client.is_connected()
+
+            if not self._redis_connected:
+                logger.warning("Redis not connected — skipping heartbeat publish")
+                return
+
+            # Publish per-agent status to agents:status channel
+            for agent_id, metrics in self._agent_metrics.items():
+                await publish_agent_status(
+                    agent_id=agent_id,
+                    status=metrics.status,
+                    details={
+                        **metrics.to_dict(),
+                        "heartbeat_seq": self._total_heartbeats,
+                    },
+                    source="heartbeat_service",
+                )
+
+            # Publish aggregate system health to system:health channel
+            summary = self.get_system_summary()
+            await client.publish(
+                Channel.SYSTEM_HEALTH.value,
+                {
+                    "event": "system_heartbeat",
+                    **summary,
+                },
+                source="heartbeat_service",
+            )
+
+            # Publish task completions to tasks:progress channel
+            for cycle_data in runner_status.get("recent_cycles", []):
+                if cycle_data.get("status") == "completed":
+                    await client.publish(
+                        Channel.TASK_PROGRESS.value,
+                        {
+                            "event": "task_completed",
+                            "agent_id": cycle_data.get("agent_id"),
+                            "agent_name": cycle_data.get("agent_name"),
+                            "tasks_processed": cycle_data.get("tasks_processed", 0),
+                            "summary": cycle_data.get("summary", ""),
+                            "completed_at": cycle_data.get("completed_at"),
+                        },
+                        source="heartbeat_service",
+                    )
+
+        except ImportError:
+            logger.debug("Redis pub/sub not available — heartbeat service running in local mode")
+            self._redis_connected = False
+        except Exception as e:
+            logger.error(f"Redis publish error: {e}")
+            self._redis_connected = False
+
+
+# Singleton
+_heartbeat_service: Optional[AgentHeartbeatService] = None
+
+
+def get_heartbeat_service() -> AgentHeartbeatService:
+    """Get the global heartbeat service singleton."""
+    global _heartbeat_service
+    if _heartbeat_service is None:
+        _heartbeat_service = AgentHeartbeatService()
+    return _heartbeat_service

--- a/mycosoft_mas/core/agent_supervisor.py
+++ b/mycosoft_mas/core/agent_supervisor.py
@@ -1,0 +1,305 @@
+"""
+Agent Supervisor — March 19, 2026
+
+Lifecycle management for MAS agents. Monitors heartbeat data, detects dead/degraded
+agents, attempts restarts, and publishes lifecycle events to Redis for the topology
+viewer and dashboard.
+
+Problem: Agents could fail silently. Nobody detects or restarts them. Morgan sees nothing.
+
+Solution: This supervisor runs as a background task, watches heartbeat metrics,
+and takes corrective action when agents go dark.
+
+NO MOCK DATA — All decisions based on real heartbeat service metrics.
+"""
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# How often the supervisor checks (seconds)
+SUPERVISOR_INTERVAL = 30
+
+# How many consecutive errors before attempting restart
+ERROR_THRESHOLD = 3
+
+# How long since last cycle before marking agent as unresponsive (seconds)
+UNRESPONSIVE_TIMEOUT = 180
+
+
+class AgentSupervisor:
+    """
+    Monitors agent health and manages lifecycle.
+
+    Responsibilities:
+    - Detect dead/unresponsive agents from heartbeat data
+    - Mark agents as degraded/error in heartbeat service
+    - Attempt agent restart via runner reload
+    - Publish lifecycle events (spawned, restarted, failed) to Redis
+    - Track restart attempts to prevent restart loops
+    """
+
+    def __init__(self):
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+        self._restart_attempts: Dict[str, int] = {}
+        self._max_restart_attempts = 3
+        self._restart_cooldown: Dict[str, float] = {}
+        self._cooldown_seconds = 300  # 5 minutes between restart attempts
+        self._lifecycle_events: List[Dict[str, Any]] = []
+
+    @property
+    def lifecycle_events(self) -> List[Dict[str, Any]]:
+        """Recent lifecycle events for dashboard display."""
+        return self._lifecycle_events[-100:]  # Keep last 100
+
+    async def start(self):
+        """Start the supervisor background loop."""
+        if self._running:
+            logger.warning("Agent supervisor already running")
+            return
+
+        self._running = True
+        self._task = asyncio.create_task(self._supervisor_loop())
+        logger.info(f"Agent supervisor started (interval={SUPERVISOR_INTERVAL}s)")
+
+        await self._publish_lifecycle_event(
+            "supervisor_started",
+            agent_id="supervisor",
+            details={"interval": SUPERVISOR_INTERVAL},
+        )
+
+    async def stop(self):
+        """Stop the supervisor."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("Agent supervisor stopped")
+
+    async def _supervisor_loop(self):
+        """Main supervision loop."""
+        await asyncio.sleep(30)  # Let system stabilize before first check
+
+        while self._running:
+            try:
+                await self._check_agents()
+            except Exception as e:
+                logger.error(f"Supervisor check error: {e}")
+
+            await asyncio.sleep(SUPERVISOR_INTERVAL)
+
+    async def _check_agents(self):
+        """Check all agents for health issues."""
+        try:
+            from mycosoft_mas.core.agent_heartbeat_service import get_heartbeat_service
+        except ImportError:
+            return
+
+        hb_service = get_heartbeat_service()
+        now = time.time()
+
+        for agent_id, metrics in hb_service.agent_metrics.items():
+            # Check for consecutive errors
+            if metrics.consecutive_errors >= ERROR_THRESHOLD:
+                await self._handle_error_agent(agent_id, metrics)
+
+            # Check for unresponsive agents (no cycle in timeout period)
+            elif metrics.last_cycle_time:
+                try:
+                    last_cycle = datetime.fromisoformat(
+                        metrics.last_cycle_time.replace("Z", "+00:00")
+                    )
+                    elapsed = (datetime.now(timezone.utc) - last_cycle).total_seconds()
+                    if elapsed > UNRESPONSIVE_TIMEOUT:
+                        await self._handle_unresponsive_agent(agent_id, elapsed)
+                except (ValueError, TypeError):
+                    pass
+
+    async def _handle_error_agent(self, agent_id: str, metrics):
+        """Handle an agent with too many consecutive errors."""
+        logger.warning(
+            f"Agent {agent_id} has {metrics.consecutive_errors} consecutive errors: "
+            f"{metrics.last_error}"
+        )
+
+        # Check cooldown
+        if not self._can_restart(agent_id):
+            return
+
+        # Attempt restart
+        await self._attempt_restart(agent_id, reason=f"consecutive_errors={metrics.consecutive_errors}")
+
+    async def _handle_unresponsive_agent(self, agent_id: str, elapsed_seconds: float):
+        """Handle an unresponsive agent."""
+        logger.warning(
+            f"Agent {agent_id} unresponsive for {elapsed_seconds:.0f}s"
+        )
+
+        # Update heartbeat status
+        try:
+            from mycosoft_mas.core.agent_heartbeat_service import get_heartbeat_service
+            hb = get_heartbeat_service()
+            if agent_id in hb.agent_metrics:
+                hb.agent_metrics[agent_id].status = "unresponsive"
+        except Exception:
+            pass
+
+        await self._publish_lifecycle_event(
+            "agent_unresponsive",
+            agent_id=agent_id,
+            details={"elapsed_seconds": elapsed_seconds},
+        )
+
+    def _can_restart(self, agent_id: str) -> bool:
+        """Check if we can attempt a restart (cooldown + max attempts)."""
+        # Check max attempts
+        attempts = self._restart_attempts.get(agent_id, 0)
+        if attempts >= self._max_restart_attempts:
+            return False
+
+        # Check cooldown
+        last_restart = self._restart_cooldown.get(agent_id, 0)
+        if time.time() - last_restart < self._cooldown_seconds:
+            return False
+
+        return True
+
+    async def _attempt_restart(self, agent_id: str, reason: str):
+        """Attempt to restart an agent via the runner."""
+        self._restart_attempts[agent_id] = self._restart_attempts.get(agent_id, 0) + 1
+        self._restart_cooldown[agent_id] = time.time()
+        attempt = self._restart_attempts[agent_id]
+
+        logger.info(f"Attempting restart of {agent_id} (attempt {attempt}/{self._max_restart_attempts}): {reason}")
+
+        try:
+            from mycosoft_mas.core.agent_runner import get_agent_runner
+            from mycosoft_mas.core.runner_agent_loader import (
+                _instantiate_native_agent,
+                LoadedRunnerAgent,
+            )
+            from mycosoft_mas.core.agent_registry import get_agent_registry
+
+            runner = get_agent_runner()
+            registry = get_agent_registry()
+            definition = registry.get(agent_id)
+
+            if not definition:
+                logger.error(f"Cannot restart {agent_id}: not found in registry")
+                await self._publish_lifecycle_event(
+                    "agent_restart_failed",
+                    agent_id=agent_id,
+                    details={"reason": "not_in_registry"},
+                )
+                return
+
+            # Try to instantiate a fresh agent
+            try:
+                delegate = _instantiate_native_agent(definition)
+                new_agent = LoadedRunnerAgent(
+                    definition=definition, delegate=delegate, mode="native"
+                )
+            except Exception as e:
+                new_agent = LoadedRunnerAgent(
+                    definition=definition, delegate=None, mode="fallback", error=str(e)
+                )
+
+            # Replace in runner's agent list
+            for i, existing in enumerate(runner._agents):
+                existing_id = getattr(existing, "agent_id", None)
+                if existing_id == agent_id:
+                    runner._agents[i] = new_agent
+                    break
+            else:
+                # Agent not in runner, add it
+                runner._agents.append(new_agent)
+
+            # Reset heartbeat metrics
+            from mycosoft_mas.core.agent_heartbeat_service import get_heartbeat_service
+            hb = get_heartbeat_service()
+            if agent_id in hb.agent_metrics:
+                hb.agent_metrics[agent_id].consecutive_errors = 0
+                hb.agent_metrics[agent_id].status = "restarted"
+
+            await self._publish_lifecycle_event(
+                "agent_restarted",
+                agent_id=agent_id,
+                details={"attempt": attempt, "reason": reason, "mode": new_agent.mode},
+            )
+
+            logger.info(f"Successfully restarted {agent_id} in {new_agent.mode} mode")
+
+        except Exception as e:
+            logger.error(f"Failed to restart {agent_id}: {e}")
+            await self._publish_lifecycle_event(
+                "agent_restart_failed",
+                agent_id=agent_id,
+                details={"attempt": attempt, "error": str(e)},
+            )
+
+    async def _publish_lifecycle_event(
+        self,
+        event_type: str,
+        agent_id: str,
+        details: Optional[Dict[str, Any]] = None,
+    ):
+        """Publish a lifecycle event to Redis and local store."""
+        event = {
+            "event": event_type,
+            "agent_id": agent_id,
+            "details": details or {},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        self._lifecycle_events.append(event)
+
+        # Publish to Redis agents:status channel
+        try:
+            from mycosoft_mas.realtime.redis_pubsub import get_client, Channel
+
+            client = await get_client()
+            if client.is_connected():
+                await client.publish(
+                    Channel.AGENTS_STATUS.value,
+                    {
+                        "agent_id": agent_id,
+                        "status": event_type,
+                        "details": details or {},
+                    },
+                    source="agent_supervisor",
+                )
+        except Exception as e:
+            logger.debug(f"Could not publish lifecycle event to Redis: {e}")
+
+        # Log to event ledger
+        try:
+            from mycosoft_mas.myca.event_ledger.ledger_writer import get_ledger
+            ledger = get_ledger()
+            ledger.log_tool_call(
+                agent="supervisor",
+                tool_name=event_type,
+                args_hash=f"agent:{agent_id}",
+                result_status="success",
+                elapsed_ms=0,
+            )
+        except Exception:
+            pass
+
+
+# Singleton
+_supervisor: Optional[AgentSupervisor] = None
+
+
+def get_supervisor() -> AgentSupervisor:
+    """Get the global agent supervisor singleton."""
+    global _supervisor
+    if _supervisor is None:
+        _supervisor = AgentSupervisor()
+    return _supervisor

--- a/mycosoft_mas/core/myca_main.py
+++ b/mycosoft_mas/core/myca_main.py
@@ -90,6 +90,8 @@ from mycosoft_mas.core.routers.ingest_api import router as ingest_router
 from mycosoft_mas.core.routers.guardian_api import router as guardian_router
 from mycosoft_mas.core.routers.investigation_api import router as investigation_router
 from mycosoft_mas.core.routers.merkle_ledger_api import router as merkle_ledger_router
+from mycosoft_mas.core.routers.event_ledger_api import router as event_ledger_router
+from mycosoft_mas.core.routers.task_intake_api import router as task_intake_router
 
 # GPU Node API for mycosoft-gpu01 compute node
 try:
@@ -600,6 +602,8 @@ app.include_router(conversation_memory_router, tags=["memory", "myca-conversatio
 app.include_router(security_router, tags=["security"])
 app.include_router(guardian_router, tags=["guardian"])
 app.include_router(merkle_ledger_router, tags=["merkle-ledger"])
+app.include_router(event_ledger_router, tags=["event-ledger"])
+app.include_router(task_intake_router, tags=["task-intake"])
 app.include_router(memory_integration_router, tags=["memory-integration"])
 app.include_router(nlq_router, tags=["nlq"])
 app.include_router(search_orchestrator_router, tags=["search"])
@@ -1445,6 +1449,24 @@ async def startup_event():
         except Exception as exc:
             logger.warning(f"STATIC index build skipped: {exc}")
 
+    # Start Agent Heartbeat Service (bridges runner → Redis → topology/dashboard)
+    try:
+        from mycosoft_mas.core.agent_heartbeat_service import get_heartbeat_service
+        heartbeat_svc = get_heartbeat_service()
+        await heartbeat_svc.start()
+        logger.info("✓ Agent heartbeat service started (publishing to Redis every 15s)")
+    except Exception as exc:
+        logger.warning(f"Heartbeat service failed to start: {exc}")
+
+    # Start Agent Supervisor (lifecycle management: detect dead agents, restart)
+    try:
+        from mycosoft_mas.core.agent_supervisor import get_supervisor
+        supervisor = get_supervisor()
+        await supervisor.start()
+        logger.info("✓ Agent supervisor started (monitoring agent health every 30s)")
+    except Exception as exc:
+        logger.warning(f"Agent supervisor failed to start: {exc}")
+
     logger.info("✓ MAS ready - all agents operational 24/7")
 
 
@@ -1474,9 +1496,20 @@ async def shutdown_event():
             logger.info("WorkflowAutoMonitor stopped")
         except Exception as exc:
             logger.warning("WorkflowAutoMonitor stop error: %s", exc)
-
-
-
+    # Stop heartbeat service
+    try:
+        from mycosoft_mas.core.agent_heartbeat_service import get_heartbeat_service
+        await get_heartbeat_service().stop()
+        logger.info("Heartbeat service stopped")
+    except Exception as exc:
+        logger.warning("Heartbeat service stop error: %s", exc)
+    # Stop agent supervisor
+    try:
+        from mycosoft_mas.core.agent_supervisor import get_supervisor
+        await get_supervisor().stop()
+        logger.info("Agent supervisor stopped")
+    except Exception as exc:
+        logger.warning("Agent supervisor stop error: %s", exc)
 
 
 

--- a/mycosoft_mas/core/routers/dashboard.py
+++ b/mycosoft_mas/core/routers/dashboard.py
@@ -1,36 +1,141 @@
-from fastapi import APIRouter, HTTPException, Depends
-from typing import Dict, Any
+"""
+Dashboard Router — March 19, 2026
+
+Real system metrics from the agent heartbeat service, health checker,
+and agent registry. NO hardcoded zeros.
+"""
+
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends
+
 from ..security import get_current_user
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
+_startup_time = time.time()
+
+
+def _get_heartbeat_summary() -> Dict[str, Any]:
+    """Get real metrics from the heartbeat service."""
+    try:
+        from mycosoft_mas.core.agent_heartbeat_service import get_heartbeat_service
+        return get_heartbeat_service().get_system_summary()
+    except Exception:
+        return {}
+
+
+def _get_registry_count() -> int:
+    """Get total registered agents from the real registry."""
+    try:
+        from mycosoft_mas.core.agent_registry import get_agent_registry
+        return len(get_agent_registry().list_all())
+    except Exception:
+        return 0
+
+
+def _uptime_str() -> str:
+    """Format uptime as human-readable string."""
+    elapsed = int(time.time() - _startup_time)
+    days, remainder = divmod(elapsed, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, _ = divmod(remainder, 60)
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    parts.append(f"{hours}h {minutes}m")
+    return " ".join(parts)
+
+
 @router.get("/")
-async def get_dashboard_data(current_user: Dict = Depends(get_current_user)) -> Dict[str, Any]:
-    """Get dashboard data."""
+async def get_dashboard_data(
+    current_user: Dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Get dashboard data from real system metrics."""
+    summary = _get_heartbeat_summary()
+    registry_count = _get_registry_count()
+
+    # Use heartbeat data if available, fall back to registry count
+    agent_count = summary.get("total_agents", 0) or registry_count
+
     return {
         "metrics": {
-            "agent_count": 0,
-            "task_count": 0,
-            "error_count": 0,
-            "api_calls": 0,
-            "cpu_usage": 0,
-            "memory_usage": 0,
-            "last_update": 0,
-            "performance_data": {
-                "labels": [],
-                "cpu": [],
-                "memory": []
-            }
+            "agent_count": agent_count,
+            "active_agents": summary.get("active_agents", 0),
+            "degraded_agents": summary.get("degraded_agents", 0),
+            "error_agents": summary.get("error_agents", 0),
+            "task_count": summary.get("total_tasks_completed", 0),
+            "error_count": summary.get("total_errors", 0),
+            "insights_count": summary.get("total_insights", 0),
+            "cpu_usage": summary.get("cpu_usage", 0),
+            "memory_usage": summary.get("memory_usage", 0),
+            "last_update": summary.get("timestamp", datetime.now(timezone.utc).isoformat()),
+            "uptime": _uptime_str(),
+            "redis_connected": summary.get("redis_connected", False),
+            "heartbeat_count": summary.get("heartbeat_count", 0),
+            "registry_agents": registry_count,
         }
     }
 
+
 @router.get("/health")
-async def get_system_health(current_user: Dict = Depends(get_current_user)) -> Dict[str, Any]:
-    """Get system health data."""
+async def get_system_health(
+    current_user: Dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Get system health data from real checks."""
+    summary = _get_heartbeat_summary()
+    registry_count = _get_registry_count()
+
+    total = summary.get("total_agents", 0) or registry_count
+    active = summary.get("active_agents", 0)
+    errors = summary.get("error_agents", 0)
+    degraded = summary.get("degraded_agents", 0)
+
+    # Calculate health score
+    if total == 0:
+        health_score = 100
+        status = "healthy"
+    else:
+        health_score = max(0, int(100 - (errors / total * 50) - (degraded / total * 20)))
+        if errors > total * 0.3:
+            status = "unhealthy"
+        elif degraded > total * 0.2 or errors > 0:
+            status = "degraded"
+        else:
+            status = "healthy"
+
+    # Check infrastructure health
+    infra_health = {}
+    try:
+        from mycosoft_mas.monitoring.health_check import HealthChecker
+        checker = HealthChecker()
+        db_health = await checker.check_database()
+        redis_health = await checker.check_redis()
+        infra_health = {
+            "postgresql": {
+                "status": db_health.status.value,
+                "latency_ms": db_health.latency_ms,
+                "message": db_health.message,
+            },
+            "redis": {
+                "status": redis_health.status.value,
+                "latency_ms": redis_health.latency_ms,
+                "message": redis_health.message,
+            },
+        }
+    except Exception:
+        pass
+
     return {
-        "status": "healthy",
-        "uptime": "0d 0h 0m",
-        "system_health": 100,
-        "active_agents": 0,
-        "total_agents": 0
-    } 
+        "status": status,
+        "uptime": _uptime_str(),
+        "system_health": health_score,
+        "active_agents": active,
+        "total_agents": total,
+        "degraded_agents": degraded,
+        "error_agents": errors,
+        "infrastructure": infra_health,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/mycosoft_mas/core/routers/event_ledger_api.py
+++ b/mycosoft_mas/core/routers/event_ledger_api.py
@@ -1,0 +1,177 @@
+"""
+Event Ledger API Router — March 19, 2026
+
+Exposes the append-only event ledger for dashboard consumption, audit trail,
+and real-time monitoring. Uses the existing EventLedger from
+mycosoft_mas/myca/event_ledger/ledger_writer.py.
+
+NO MOCK DATA — reads from the real JSONL event log.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/events", tags=["Event Ledger"])
+
+
+def _get_ledger():
+    """Get the event ledger singleton."""
+    from mycosoft_mas.myca.event_ledger.ledger_writer import get_ledger
+    return get_ledger()
+
+
+@router.get("/recent")
+async def get_recent_events(
+    limit: int = Query(100, ge=1, le=1000),
+    agent: Optional[str] = Query(None, description="Filter by agent name"),
+    tool: Optional[str] = Query(None, description="Filter by tool name"),
+    status: Optional[str] = Query(None, description="Filter by result_status"),
+    since_ts: Optional[int] = Query(None, description="Only events after this unix timestamp"),
+) -> Dict[str, Any]:
+    """Get recent events from the event ledger with optional filtering."""
+    ledger = _get_ledger()
+    events = ledger.read_events(
+        since_ts=since_ts,
+        agent=agent,
+        tool=tool,
+        status=status,
+        limit=limit,
+    )
+
+    return {
+        "events": events,
+        "count": len(events),
+        "filters": {
+            "agent": agent,
+            "tool": tool,
+            "status": status,
+            "since_ts": since_ts,
+        },
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/failures")
+async def get_failure_summary(
+    hours: int = Query(24, ge=1, le=168, description="Hours to look back"),
+) -> Dict[str, Any]:
+    """Get failure summary for the specified time window."""
+    ledger = _get_ledger()
+    summary = ledger.get_failure_summary(hours=hours)
+
+    return {
+        "summary": summary,
+        "hours": hours,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/telemetry")
+async def get_telemetry_chain(
+    device_id: Optional[str] = Query(None, description="Filter by device ID"),
+    limit: int = Query(100, ge=1, le=1000),
+) -> Dict[str, Any]:
+    """Get telemetry provenance chain from the event ledger."""
+    ledger = _get_ledger()
+    chain = ledger.read_telemetry_chain(device_id=device_id, limit=limit)
+
+    return {
+        "chain": chain,
+        "count": len(chain),
+        "device_id": device_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/stream")
+async def stream_events():
+    """
+    SSE endpoint for real-time event streaming.
+
+    Tails the event ledger file and pushes new events as they arrive.
+    Clients connect via EventSource: new EventSource('/api/events/stream')
+    """
+    async def event_generator():
+        ledger = _get_ledger()
+        ledger_file = ledger.current_ledger_file
+
+        # Start from end of file
+        try:
+            with open(ledger_file, "r") as f:
+                f.seek(0, 2)  # Seek to end
+                last_pos = f.tell()
+        except FileNotFoundError:
+            last_pos = 0
+
+        yield f"data: {json.dumps({'event': 'connected', 'timestamp': datetime.now(timezone.utc).isoformat()})}\n\n"
+
+        while True:
+            try:
+                with open(ledger_file, "r") as f:
+                    f.seek(last_pos)
+                    new_lines = f.readlines()
+                    last_pos = f.tell()
+
+                for line in new_lines:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        event = json.loads(line)
+                        yield f"data: {json.dumps(event)}\n\n"
+                    except json.JSONDecodeError:
+                        continue
+
+            except FileNotFoundError:
+                pass
+
+            # Send keepalive ping every 15 seconds
+            yield f": keepalive {datetime.now(timezone.utc).isoformat()}\n\n"
+            await asyncio.sleep(5)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.get("/stats")
+async def get_ledger_stats() -> Dict[str, Any]:
+    """Get overall ledger statistics."""
+    ledger = _get_ledger()
+    all_events = ledger.read_events(limit=10000)
+
+    # Count by type
+    by_status: Dict[str, int] = {}
+    by_agent: Dict[str, int] = {}
+    by_type: Dict[str, int] = {}
+
+    for event in all_events:
+        status = event.get("result_status", "unknown")
+        agent = event.get("agent", "unknown")
+        event_type = event.get("event_type", "tool_call")
+
+        by_status[status] = by_status.get(status, 0) + 1
+        by_agent[agent] = by_agent.get(agent, 0) + 1
+        by_type[event_type] = by_type.get(event_type, 0) + 1
+
+    return {
+        "total_events": len(all_events),
+        "by_status": by_status,
+        "by_agent": by_agent,
+        "by_type": by_type,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/mycosoft_mas/core/routers/orchestrator_api.py
+++ b/mycosoft_mas/core/routers/orchestrator_api.py
@@ -1,14 +1,17 @@
 """
-Orchestrator API Router - Provides endpoints for the MYCA orchestrator dashboard.
+Orchestrator API Router — March 19, 2026
 
-All data is REAL from the agent registry and runtime pool. No mock data.
-Updated: Feb 9, 2026 - Removed all hardcoded mock data, uses core agent registry.
+Provides endpoints for the MYCA orchestrator dashboard (AI Studio / PersonaPlex).
+All data is REAL from the agent registry, heartbeat service, and runner.
+
+Updated: March 19, 2026 — Wired to heartbeat service for real runtime metrics.
 """
 
 from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 from datetime import datetime, timezone
+from dataclasses import asdict
 import logging
 import time
 
@@ -26,22 +29,78 @@ def _get_registry():
     return get_agent_registry()
 
 
+def _get_heartbeat_metrics() -> Dict[str, Any]:
+    """Get per-agent runtime metrics from the heartbeat service."""
+    try:
+        from mycosoft_mas.core.agent_heartbeat_service import get_heartbeat_service
+        svc = get_heartbeat_service()
+        return {
+            agent_id: m.to_dict()
+            for agent_id, m in svc.agent_metrics.items()
+        }
+    except Exception:
+        return {}
+
+
+def _get_heartbeat_summary() -> Dict[str, Any]:
+    """Get aggregate system metrics from the heartbeat service."""
+    try:
+        from mycosoft_mas.core.agent_heartbeat_service import get_heartbeat_service
+        return get_heartbeat_service().get_system_summary()
+    except Exception:
+        return {}
+
+
+def _get_runner_status() -> Dict[str, Any]:
+    """Get runner status (recent cycles, insights, notifications)."""
+    try:
+        from mycosoft_mas.core.agent_runner import get_agent_runner
+        import asyncio
+        runner = get_agent_runner()
+        # Return synchronous data (no await needed for these attributes)
+        return {
+            "running": runner.running,
+            "agent_count": len(runner._agents),
+            "total_cycles": len(runner.cycles),
+            "total_insights": len(runner.insights),
+            "total_notifications": len(runner.notifications),
+            "recent_notifications": [
+                asdict(n) for n in runner.notifications[-20:]
+            ],
+            "recent_insights": [
+                asdict(i) for i in runner.insights[-20:]
+            ],
+        }
+    except Exception:
+        return {}
+
+
 def _build_agent_list() -> List[Dict[str, Any]]:
-    """Build agent list from the REAL core registry. No mock data."""
+    """Build agent list from REAL registry + REAL runtime metrics."""
     registry = _get_registry()
     agents = registry.list_all()
+    hb_metrics = _get_heartbeat_metrics()
     result = []
     for a in agents:
+        metrics = hb_metrics.get(a.agent_id, {})
+        runtime_status = metrics.get("status", "idle") if metrics else "idle"
+        # If agent is in registry and marked active, show at least "idle"
+        if a.is_active and runtime_status == "idle" and not metrics:
+            runtime_status = "registered"
+
         result.append({
             "id": a.agent_id,
             "name": a.name,
             "displayName": a.display_name,
             "category": a.category.value,
-            "status": "active" if a.is_active else "idle",
-            "tasksCompleted": 0,
-            "tasksInProgress": 0,
-            "cpuUsage": 0,
-            "memoryUsage": 0,
+            "status": runtime_status,
+            "tasksCompleted": metrics.get("tasks_completed", 0),
+            "tasksFailed": metrics.get("tasks_failed", 0),
+            "insightsGenerated": metrics.get("insights_generated", 0),
+            "cycleCount": metrics.get("cycle_count", 0),
+            "lastCycleTime": metrics.get("last_cycle_time"),
+            "consecutiveErrors": metrics.get("consecutive_errors", 0),
+            "lastError": metrics.get("last_error"),
             "capabilities": [c.value for c in a.capabilities],
             "keywords": a.keywords,
         })
@@ -63,40 +122,57 @@ def _uptime_str() -> str:
 
 @router.get("/dashboard")
 async def get_dashboard_data() -> Dict[str, Any]:
-    """Get complete dashboard data from REAL agent registry. No mock data."""
+    """Get complete dashboard data from REAL agent registry + runtime metrics."""
     agents = _build_agent_list()
-    active_agents = [a for a in agents if a["status"] == "active"]
+    summary = _get_heartbeat_summary()
+    runner = _get_runner_status()
+
     total = len(agents)
-    active = len(active_agents)
+    active = sum(1 for a in agents if a["status"] in ("active", "registered"))
+    idle = sum(1 for a in agents if a["status"] == "idle")
+
+    # Get Redis pub/sub stats for messages/second
+    try:
+        from mycosoft_mas.realtime.redis_pubsub import get_client
+        client = await get_client()
+        pubsub_stats = client.get_stats()
+        msgs_published = pubsub_stats.get("messages_published", 0)
+    except Exception:
+        msgs_published = 0
 
     return {
         "agents": agents,
         "metrics": {
             "totalAgents": total,
             "activeAgents": active,
-            "idleAgents": total - active,
-            "totalTasks": 0,
-            "completedTasks": 0,
-            "messagesPerSecond": 0,
+            "idleAgents": idle,
+            "errorAgents": summary.get("error_agents", 0),
+            "degradedAgents": summary.get("degraded_agents", 0),
+            "totalTasks": summary.get("total_tasks_completed", 0),
+            "completedTasks": summary.get("total_tasks_completed", 0),
+            "totalErrors": summary.get("total_errors", 0),
+            "totalInsights": summary.get("total_insights", 0),
+            "messagesPublished": msgs_published,
             "uptime": _uptime_str(),
-            "cpuUsage": 0,
-            "memoryUsage": 0,
+            "cpuUsage": summary.get("cpu_usage", 0),
+            "memoryUsage": summary.get("memory_usage", 0),
+            "redisConnected": summary.get("redis_connected", False),
         },
-        "messages": [],
-        "insights": [],
-        "memory": {
-            "shortTermCount": 0,
-            "longTermCount": 0,
-            "knowledgePools": [],
+        "messages": runner.get("recent_notifications", []),
+        "insights": runner.get("recent_insights", []),
+        "runner": {
+            "running": runner.get("running", False),
+            "totalCycles": runner.get("total_cycles", 0),
+            "agentsLoaded": runner.get("agent_count", 0),
         },
     }
 
 
 @router.get("/agents")
 async def get_agents() -> Dict[str, Any]:
-    """Get list of ALL registered agents from the core registry."""
+    """Get list of ALL registered agents with real runtime status."""
     agents = _build_agent_list()
-    active = [a for a in agents if a["status"] == "active"]
+    active = [a for a in agents if a["status"] in ("active", "registered")]
     return {
         "agents": agents,
         "totalAgents": len(agents),
@@ -104,35 +180,82 @@ async def get_agents() -> Dict[str, Any]:
     }
 
 
+@router.get("/agents/{agent_id}")
+async def get_agent_detail(agent_id: str) -> Dict[str, Any]:
+    """Get detailed info for a specific agent."""
+    registry = _get_registry()
+    definition = registry.get(agent_id)
+    if not definition:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
+
+    hb_metrics = _get_heartbeat_metrics()
+    metrics = hb_metrics.get(agent_id, {})
+
+    return {
+        "id": definition.agent_id,
+        "name": definition.name,
+        "displayName": definition.display_name,
+        "description": definition.description,
+        "category": definition.category.value,
+        "capabilities": [c.value for c in definition.capabilities],
+        "modulePath": definition.module_path,
+        "className": definition.class_name,
+        "keywords": definition.keywords,
+        "voiceTriggers": definition.voice_triggers,
+        "requiresConfirmation": definition.requires_confirmation,
+        "isActive": definition.is_active,
+        "runtime": metrics,
+    }
+
+
 @router.get("/metrics")
 async def get_metrics() -> Dict[str, Any]:
-    """Get system metrics from real registry."""
-    data = await get_dashboard_data()
-    return data["metrics"]
+    """Get real system metrics from heartbeat service."""
+    summary = _get_heartbeat_summary()
+    agents = _build_agent_list()
+    return {
+        "totalAgents": len(agents),
+        "activeAgents": summary.get("active_agents", 0),
+        "totalTasks": summary.get("total_tasks_completed", 0),
+        "totalErrors": summary.get("total_errors", 0),
+        "totalInsights": summary.get("total_insights", 0),
+        "cpuUsage": summary.get("cpu_usage", 0),
+        "memoryUsage": summary.get("memory_usage", 0),
+        "uptime": _uptime_str(),
+        "redisConnected": summary.get("redis_connected", False),
+    }
 
 
 @router.get("/insights")
 async def get_insights(limit: int = 20) -> Dict[str, Any]:
-    """Get recent system insights (empty until real event system is wired)."""
-    return {"insights": []}
+    """Get recent system insights from the agent runner."""
+    runner = _get_runner_status()
+    insights = runner.get("recent_insights", [])[:limit]
+    return {"insights": insights, "total": len(insights)}
 
 
 @router.get("/messages")
 async def get_messages(limit: int = 50) -> Dict[str, Any]:
-    """Get recent system messages (empty until real message broker is wired)."""
-    return {"messages": []}
+    """Get recent system messages/notifications from the agent runner."""
+    runner = _get_runner_status()
+    messages = runner.get("recent_notifications", [])[:limit]
+    return {"messages": messages, "total": len(messages)}
 
 
 @router.get("/status")
 async def get_orchestrator_status() -> Dict[str, Any]:
-    """Get orchestrator status with real agent count."""
+    """Get orchestrator status with real runtime data."""
     registry = _get_registry()
+    summary = _get_heartbeat_summary()
+    runner = _get_runner_status()
     total = len(registry.list_all())
-    active = len(registry.list_active())
+
     return {
-        "running": True,
-        "startTime": datetime.now(timezone.utc).isoformat(),
+        "running": runner.get("running", True),
+        "startTime": datetime.fromtimestamp(_startup_time, tz=timezone.utc).isoformat(),
         "agentCount": total,
-        "activeAgents": active,
+        "activeAgents": summary.get("active_agents", 0),
+        "runnerCycles": runner.get("total_cycles", 0),
         "uptime": _uptime_str(),
+        "redisConnected": summary.get("redis_connected", False),
     }

--- a/mycosoft_mas/core/routers/task_intake_api.py
+++ b/mycosoft_mas/core/routers/task_intake_api.py
@@ -1,0 +1,229 @@
+"""
+Unified Task Intake API — March 19, 2026
+
+Canonical entry point for submitting tasks to the MAS. Routes tasks to the
+appropriate agent based on intent classification, publishes to Redis for
+real-time tracking, and records in the event ledger.
+
+Previously tasks could enter via orchestrator_api, agent_runner_api, a2a_api,
+or ingest_api — but there was no single canonical intake with routing + tracking.
+
+NO MOCK DATA — Routes to real agents via the registry + runner.
+"""
+
+import logging
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/tasks", tags=["Task Intake"])
+
+
+class TaskSubmission(BaseModel):
+    """A task to submit to the MAS."""
+    description: str = Field(..., description="What needs to be done")
+    task_type: Optional[str] = Field(None, description="Explicit task type (query, etl, search, deploy, etc.)")
+    target_agent: Optional[str] = Field(None, description="Specific agent ID to route to")
+    priority: str = Field("normal", description="low, normal, high, critical")
+    payload: Dict[str, Any] = Field(default_factory=dict, description="Additional task data")
+    source: str = Field("user", description="Who submitted (user, agent, n8n, api)")
+
+
+class TaskStatus(BaseModel):
+    task_id: str
+    status: str
+    agent_id: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None
+    submitted_at: str
+    completed_at: Optional[str] = None
+
+
+# In-memory task store (recent tasks for dashboard visibility)
+_task_store: Dict[str, Dict[str, Any]] = {}
+
+
+def _route_task_to_agent(task: TaskSubmission) -> Optional[str]:
+    """Route a task to the best-fit agent based on keywords and type."""
+    if task.target_agent:
+        return task.target_agent
+
+    try:
+        from mycosoft_mas.core.agent_registry import get_agent_registry
+        registry = get_agent_registry()
+
+        # Try type-based routing
+        type_to_agent = {
+            "query": "mindex-agent",
+            "search": "search-agent",
+            "etl": "etl-agent",
+            "deploy": "deployment-agent",
+            "security": "security-agent",
+            "finance": "financial-agent",
+            "mycology": "mycology-bio-agent",
+            "scientific": "lab-agent",
+            "earth2": "earth2-orchestrator",
+        }
+        if task.task_type and task.task_type.lower() in type_to_agent:
+            agent_id = type_to_agent[task.task_type.lower()]
+            if registry.get(agent_id):
+                return agent_id
+
+        # Try keyword-based routing
+        description_lower = task.description.lower()
+        results = registry.find_by_keyword(description_lower[:50])
+        if results:
+            return results[0].agent_id
+
+        # Default to manager agent for routing
+        return "manager-agent"
+    except Exception:
+        return "manager-agent"
+
+
+@router.post("/submit")
+async def submit_task(task: TaskSubmission) -> Dict[str, Any]:
+    """Submit a task to the MAS for processing.
+
+    The task is routed to the best-fit agent, published to Redis for
+    real-time tracking, and recorded in the event ledger.
+    """
+    task_id = f"task_{uuid.uuid4().hex[:12]}"
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Route to agent
+    agent_id = _route_task_to_agent(task)
+
+    # Store task
+    task_record = {
+        "task_id": task_id,
+        "description": task.description,
+        "task_type": task.task_type,
+        "target_agent": agent_id,
+        "priority": task.priority,
+        "payload": task.payload,
+        "source": task.source,
+        "status": "submitted",
+        "submitted_at": now,
+        "completed_at": None,
+        "result": None,
+    }
+    _task_store[task_id] = task_record
+
+    # Publish to Redis tasks:progress channel
+    try:
+        from mycosoft_mas.realtime.redis_pubsub import get_client, Channel
+
+        client = await get_client()
+        if client.is_connected():
+            await client.publish(
+                Channel.TASK_PROGRESS.value,
+                {
+                    "event": "task_submitted",
+                    "task_id": task_id,
+                    "agent_id": agent_id,
+                    "description": task.description,
+                    "priority": task.priority,
+                    "source": task.source,
+                },
+                source="task_intake",
+            )
+    except Exception as e:
+        logger.debug(f"Could not publish task to Redis: {e}")
+
+    # Log to event ledger
+    try:
+        from mycosoft_mas.myca.event_ledger.ledger_writer import get_ledger
+        ledger = get_ledger()
+        ledger.log_tool_call(
+            agent=task.source,
+            tool_name="task_submit",
+            args_hash=f"task:{task_id}",
+            result_status="success",
+        )
+    except Exception:
+        pass
+
+    # Queue task in the runner if agent is available
+    try:
+        from mycosoft_mas.core.agent_runner import get_agent_runner
+        runner = get_agent_runner()
+        for agent in runner._agents:
+            aid = getattr(agent, "agent_id", None)
+            if aid == agent_id and hasattr(agent, "task_queue"):
+                await agent.task_queue.put(task.payload)
+                task_record["status"] = "queued"
+                break
+    except Exception:
+        pass
+
+    return {
+        "task_id": task_id,
+        "status": task_record["status"],
+        "routed_to": agent_id,
+        "submitted_at": now,
+    }
+
+
+@router.get("/status/{task_id}")
+async def get_task_status(task_id: str) -> Dict[str, Any]:
+    """Get the status of a submitted task."""
+    task = _task_store.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+    return task
+
+
+@router.get("/recent")
+async def get_recent_tasks(
+    limit: int = 50,
+    status: Optional[str] = None,
+    source: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get recent submitted tasks."""
+    tasks = list(_task_store.values())
+
+    if status:
+        tasks = [t for t in tasks if t["status"] == status]
+    if source:
+        tasks = [t for t in tasks if t["source"] == source]
+
+    # Sort by submitted_at descending
+    tasks.sort(key=lambda t: t["submitted_at"], reverse=True)
+    tasks = tasks[:limit]
+
+    return {
+        "tasks": tasks,
+        "total": len(tasks),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/agents")
+async def get_routable_agents() -> Dict[str, Any]:
+    """Get list of agents that can receive tasks, with their capabilities."""
+    try:
+        from mycosoft_mas.core.agent_registry import get_agent_registry
+        registry = get_agent_registry()
+        agents = registry.list_active()
+
+        return {
+            "agents": [
+                {
+                    "agent_id": a.agent_id,
+                    "name": a.display_name,
+                    "category": a.category.value,
+                    "capabilities": [c.value for c in a.capabilities],
+                    "keywords": a.keywords,
+                }
+                for a in agents
+            ],
+            "total": len(agents),
+        }
+    except Exception:
+        return {"agents": [], "total": 0}

--- a/mycosoft_mas/memory/graph_memory.py
+++ b/mycosoft_mas/memory/graph_memory.py
@@ -20,12 +20,21 @@ class GraphEdge:
         self.properties = properties or {}
 
 class GraphMemory:
-    """Knowledge graph for structured memory."""
-    
+    """Knowledge graph for structured memory.
+
+    Performance indexes (March 19, 2026):
+    - _type_index: node_type → set of node_ids for O(1) type lookups
+    - _reverse_adjacency: target → set of sources for bidirectional traversal
+    - _edge_index: (source, target) → list of edges for fast relationship lookup
+    """
+
     def __init__(self, database_url: Optional[str] = None):
         self._nodes: Dict[UUID, GraphNode] = {}
         self._edges: List[GraphEdge] = []
         self._adjacency: Dict[UUID, Set[UUID]] = {}
+        self._reverse_adjacency: Dict[UUID, Set[UUID]] = {}
+        self._type_index: Dict[str, Set[UUID]] = {}
+        self._edge_index: Dict[Tuple[UUID, UUID], List[GraphEdge]] = {}
         self._database_url = database_url or os.getenv("MINDEX_DATABASE_URL")
         self._pool = None
         self._persistence_enabled = False
@@ -81,6 +90,11 @@ class GraphMemory:
         node_id = uuid4()
         self._nodes[node_id] = GraphNode(node_id, node_type, properties)
         self._adjacency[node_id] = set()
+        self._reverse_adjacency[node_id] = set()
+        # Maintain type index
+        if node_type not in self._type_index:
+            self._type_index[node_type] = set()
+        self._type_index[node_type].add(node_id)
         return node_id
 
     def add_edge(self, source: UUID, target: UUID, relationship: str, properties: Optional[Dict[str, Any]] = None) -> bool:
@@ -100,6 +114,14 @@ class GraphMemory:
         edge = GraphEdge(source, target, relationship, properties)
         self._edges.append(edge)
         self._adjacency[source].add(target)
+        # Maintain reverse adjacency and edge index
+        if target not in self._reverse_adjacency:
+            self._reverse_adjacency[target] = set()
+        self._reverse_adjacency[target].add(source)
+        edge_key = (source, target)
+        if edge_key not in self._edge_index:
+            self._edge_index[edge_key] = []
+        self._edge_index[edge_key].append(edge)
         if self._persistence_enabled:
             try:
                 loop = asyncio.get_running_loop()
@@ -182,11 +204,93 @@ class GraphMemory:
     def query(self, node_type: Optional[str] = None, relationship: Optional[str] = None) -> List[Dict[str, Any]]:
         results = []
         if node_type:
-            for node in self._nodes.values():
-                if node.node_type == node_type:
-                    results.append({"node_id": str(node.node_id), "type": node.node_type, "properties": node.properties})
+            # Use type index for O(1) lookup instead of scanning all nodes
+            for node_id in self._type_index.get(node_type, set()):
+                node = self._nodes[node_id]
+                results.append({"node_id": str(node.node_id), "type": node.node_type, "properties": node.properties})
         if relationship:
             for edge in self._edges:
                 if edge.relationship == relationship:
                     results.append({"source": str(edge.source), "target": str(edge.target), "relationship": edge.relationship})
         return results
+
+    def find_neighbors_with_edges(self, node_id: UUID, direction: str = "outgoing") -> List[Dict[str, Any]]:
+        """Fast 1-hop neighbor query with relationship info.
+
+        Args:
+            node_id: The node to query from.
+            direction: 'outgoing', 'incoming', or 'both'.
+
+        Returns:
+            List of {neighbor_id, relationship, direction, properties} dicts.
+        """
+        results = []
+        if direction in ("outgoing", "both"):
+            for neighbor_id in self._adjacency.get(node_id, set()):
+                for edge in self._edge_index.get((node_id, neighbor_id), []):
+                    results.append({
+                        "neighbor_id": str(neighbor_id),
+                        "relationship": edge.relationship,
+                        "direction": "outgoing",
+                        "properties": edge.properties,
+                    })
+        if direction in ("incoming", "both"):
+            for source_id in self._reverse_adjacency.get(node_id, set()):
+                for edge in self._edge_index.get((source_id, node_id), []):
+                    results.append({
+                        "neighbor_id": str(source_id),
+                        "relationship": edge.relationship,
+                        "direction": "incoming",
+                        "properties": edge.properties,
+                    })
+        return results
+
+    def get_nodes_by_type(self, node_type: str) -> List[GraphNode]:
+        """O(1) lookup of all nodes with a given type using type index."""
+        return [self._nodes[nid] for nid in self._type_index.get(node_type, set()) if nid in self._nodes]
+
+    def get_edges_between(self, source: UUID, target: UUID) -> List[GraphEdge]:
+        """O(1) lookup of all edges between two nodes."""
+        return self._edge_index.get((source, target), [])
+
+    def get_agent_topology(self) -> Dict[str, Any]:
+        """Build the agent topology subgraph for the topology viewer.
+
+        Returns a dict with 'nodes' and 'edges' arrays suitable for visualization.
+        """
+        agent_nodes = self.get_nodes_by_type("agent")
+        node_ids = {n.node_id for n in agent_nodes}
+
+        nodes = []
+        for node in agent_nodes:
+            nodes.append({
+                "id": str(node.node_id),
+                "type": node.node_type,
+                "properties": node.properties,
+            })
+
+        edges = []
+        for edge in self._edges:
+            if edge.source in node_ids or edge.target in node_ids:
+                edges.append({
+                    "source": str(edge.source),
+                    "target": str(edge.target),
+                    "relationship": edge.relationship,
+                    "properties": edge.properties,
+                })
+
+        return {
+            "nodes": nodes,
+            "edges": edges,
+            "node_count": len(nodes),
+            "edge_count": len(edges),
+        }
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get graph statistics for monitoring."""
+        return {
+            "total_nodes": len(self._nodes),
+            "total_edges": len(self._edges),
+            "node_types": {t: len(ids) for t, ids in self._type_index.items()},
+            "persistence_enabled": self._persistence_enabled,
+        }


### PR DESCRIPTION
The MAS had 158+ agents registered, 98 routers, 16+ WebSocket streams,
Redis pub/sub, and Prometheus utils — but nothing was connected. The
orchestrator API returned hardcoded zeros, agents didn't broadcast
heartbeats, the topology viewer got silence from Redis, and Morgan
had zero visibility.

Root cause: each component was built in isolation; the glue layer was
never written. This commit adds that glue.

New components:
- agent_heartbeat_service.py: polls runner every 15s, publishes to
  Redis agents:status / system:health / tasks:progress channels
- agent_supervisor.py: detects dead/degraded agents, attempts restart,
  publishes lifecycle events
- event_ledger_api.py: exposes append-only audit trail via REST + SSE
- task_intake_api.py: unified task submission with auto-routing to
  best-fit agent, Redis tracking, event ledger logging

Fixed components:
- dashboard.py: replaced stub (all zeros) with real heartbeat + health
  checker data including CPU, memory, Redis status, infrastructure
- orchestrator_api.py: wired to heartbeat service for real per-agent
  metrics (tasksCompleted, cycleCount, lastCycleTime, errors)
- myca_main.py: starts heartbeat service + supervisor on boot, stops
  on shutdown, registers event_ledger and task_intake routers
- graph_memory.py: added type_index, reverse_adjacency, edge_index for
  O(1) lookups; added find_neighbors_with_edges, get_agent_topology,
  get_stats methods
- data_agents.py: MindexAgent v2 now queries real MINDEX API (taxa,
  observations, search, health) instead of returning empty stubs

https://claude.ai/code/session_01GUUxjdpxwfNt7psrxWhSJ3