### PR TITLE
Fix Qdrant health check: use bash /dev/tcp instead of wget/curl

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -165,10 +165,11 @@ services:
     environment:
       - QDRANT__SERVICE__GRPC_PORT=6334
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6333/readyz"]
+      test: ["CMD-SHELL", "bash -c ':> /dev/tcp/0.0.0.0/6333' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 15s
     networks:
       - mas-network
     restart: unless-stopped

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,7 +54,7 @@ services:
     networks:
       - mas-network
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:6333/readyz || exit 1"]
+      test: ["CMD-SHELL", "bash -c ':> /dev/tcp/0.0.0.0/6333' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
The qdrant/qdrant Docker image does not include wget or curl (security decision by Qdrant maintainers), causing the health check to always fail and blocking the orchestrator from starting. Use bash TCP connectivity check instead.

https://claude.ai/code/session_01GUaSJAsbzKSKVVqiwTMorU