### PR TITLE
Fix secrets context in workflow if-expression

### DIFF
--- a/.github/workflows/deploy-to-vms.yml
+++ b/.github/workflows/deploy-to-vms.yml
@@ -87,7 +87,7 @@ jobs:
             sleep 5
             curl -sf http://localhost:3000 -o /dev/null || exit 1
       - name: Purge Cloudflare cache
-        if: success() && secrets.CLOUDFLARE_ZONE_ID != ''
+        if: ${{ success() && secrets.CLOUDFLARE_ZONE_ID != '' }}
         run: |
           curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
             -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \


### PR DESCRIPTION
secrets must be wrapped in ${{ }} when used in if: conditions.

https://claude.ai/code/session_016VhZfrbsCXoTkH3LhiZXD8

## Summary by Sourcery

CI:
- Fix the deploy-to-vms workflow conditional to use expression syntax when checking for the Cloudflare zone ID secret.