### PR TITLE
Fix deploy-to-vms workflow: secrets not allowed in if-expressions

### DIFF
--- a/.github/workflows/deploy-to-vms.yml
+++ b/.github/workflows/deploy-to-vms.yml
@@ -87,9 +87,14 @@ jobs:
             sleep 5
             curl -sf http://localhost:3000 -o /dev/null || exit 1
       - name: Purge Cloudflare cache
-        if: ${{ success() && secrets.CLOUDFLARE_ZONE_ID != '' }}
+        if: success()
+        env:
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
-            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            --data '{"purge_everything":true}'
+          if [ -n "$CLOUDFLARE_ZONE_ID" ]; then
+            curl -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data '{"purge_everything":true}'
+          fi


### PR DESCRIPTION
GitHub Actions doesn't expose the secrets context in if: conditions. Moved secret references to env vars and use a shell conditional instead.

https://claude.ai/code/session_016VhZfrbsCXoTkH3LhiZXD8

## Summary by Sourcery

Bug Fixes:
- Fix Cloudflare cache purge step in the deploy-to-vms workflow by moving secret checks from the workflow if-condition into the shell script using environment variables.