### PR TITLE
ci: fix broken YAML indentation in dependencies.yml

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -3,11 +3,11 @@ name: Dependencies
 on:
   push:
     paths:
-            - 'pyproject.toml'
+      - 'pyproject.toml'
       - '.github/workflows/dependencies.yml'
   pull_request:
     paths:
-            - 'pyproject.toml'
+      - 'pyproject.toml'
       - '.github/workflows/dependencies.yml'
   schedule:
     - cron: '0 0 * * *'  # Daily at midnight


### PR DESCRIPTION
The previous commit (c0fc0ef) introduced incorrect indentation when removing the requirements.in path, causing YAML parse errors and workflow failures on every push to main.

https://claude.ai/code/session_01EG5H4hQ6QYKJ28tezJzNk7

## Summary by Sourcery

CI:
- Correct YAML indentation for the dependencies workflow path filters to prevent workflow failures on push and pull request events.