### PR TITLE
Security hardening: fix 13 vulnerabilities from pen test

### DIFF
--- a/mycosoft_mas/agents/crypto/ows_wallet_agent.py
+++ b/mycosoft_mas/agents/crypto/ows_wallet_agent.py
@@ -224,6 +224,10 @@ class OWSWalletAgent(BaseAgent):
         if not from_agent or not to_agent or amount <= 0:
             return {"status": "error", "error": "from_agent_id, to_agent_id, amount required"}
 
+        # Minimum transfer: 0.00000001 (1 sat equivalent) — prevent dust/rounding exploits
+        if amount < Decimal("0.00000001"):
+            return {"status": "error", "error": "Amount below minimum (0.00000001)"}
+
         col = CURRENCY_COLUMN_MAP.get(currency)
         if not col:
             return {"status": "error", "error": f"Unsupported currency: {currency}"}
@@ -343,15 +347,27 @@ class OWSWalletAgent(BaseAgent):
             return {"status": "error", "error": str(e)}
 
     async def _handle_fund_wallet(self, task: Dict[str, Any]) -> Dict[str, Any]:
-        """Record external funding of an agent wallet."""
+        """Record external funding of an agent wallet.
+
+        SECURITY: This should ONLY be called by verified payment webhooks
+        (Stripe webhook, on-chain tx verifier) — never by an agent directly.
+        The tx_hash must be verified against the actual blockchain before calling this.
+        The caller must set verified=True to confirm the funding is real.
+        """
         agent_id = task.get("agent_id", "")
         amount = Decimal(str(task.get("amount", 0)))
         currency = task.get("currency", "SOL").upper()
         tx_hash = task.get("tx_hash")
+        verified = task.get("verified", False)
+
+        if not verified:
+            return {"status": "error", "error": "Funding must be verified (verified=True). Only payment webhooks may credit balances."}
 
         col = CURRENCY_COLUMN_MAP.get(currency)
         if not agent_id or amount <= 0 or not col:
             return {"status": "error", "error": "agent_id, amount, valid currency required"}
+        if not tx_hash:
+            return {"status": "error", "error": "tx_hash required for verified funding"}
 
         mindex = self._get_mindex()
         if not mindex:

--- a/mycosoft_mas/core/routers/ows_wallet_api.py
+++ b/mycosoft_mas/core/routers/ows_wallet_api.py
@@ -41,7 +41,7 @@ router = APIRouter(prefix="/api/wallet/ows", tags=["ows-wallet", "crypto", "paym
 
 
 # ---------------------------------------------------------------------------
-# CEO auth dependency (lazy import to avoid circular deps at module load)
+# Auth dependencies
 # ---------------------------------------------------------------------------
 
 
@@ -50,6 +50,14 @@ async def _require_ceo_auth_dep(request: Request) -> str:
     from mycosoft_mas.security.treasury_auth import require_ceo_auth
 
     return await require_ceo_auth(request)
+
+
+async def _require_agent_auth(request: Request) -> str:
+    """Require a valid RaaS API key. Returns the authenticated agent_id."""
+    from mycosoft_mas.raas.middleware import require_raas_auth
+
+    agent = await require_raas_auth(request)
+    return agent.agent_id
 
 
 # Lazy singletons
@@ -87,8 +95,8 @@ def _get_mindex():
 
 
 class CreateWalletRequest(BaseModel):
-    agent_id: str = Field(..., min_length=1)
-    wallet_name: Optional[str] = None
+    agent_id: str = Field(..., min_length=1, max_length=64)
+    wallet_name: Optional[str] = Field(None, max_length=128)
     wallet_type: str = Field(default="internal", pattern="^(internal|external|treasury)$")
 
 
@@ -101,9 +109,9 @@ class CreateWalletResponse(BaseModel):
 
 
 class TransferRequest(BaseModel):
-    from_agent_id: str = Field(..., min_length=1)
-    to_agent_id: str = Field(..., min_length=1)
-    amount: float = Field(..., gt=0)
+    from_agent_id: str = Field(..., min_length=1, max_length=64)
+    to_agent_id: str = Field(..., min_length=1, max_length=64)
+    amount: float = Field(..., gt=0.00000001, le=1000000)  # Min dust threshold, max sanity cap
     currency: str = Field(default="SOL", pattern="^(SOL|USDC|ETH|BTC)$")
 
 
@@ -130,10 +138,10 @@ class FundResponse(BaseModel):
 
 
 class PayRequest(BaseModel):
-    agent_id: str = Field(..., min_length=1)
-    service_id: str = Field(..., min_length=1)
-    amount: float = Field(..., gt=0)
-    currency: str = Field(default="SOL")
+    agent_id: str = Field(..., min_length=1, max_length=64)
+    service_id: str = Field(..., min_length=1, max_length=128)
+    amount: float = Field(..., gt=0.00000001, le=1000000)
+    currency: str = Field(default="SOL", pattern="^(SOL|USDC|ETH|BTC)$")
 
 
 class SignRequest(BaseModel):
@@ -174,7 +182,7 @@ class TreasurySettingsUpdate(BaseModel):
     withdrawal_address_solana: Optional[str] = None
     withdrawal_address_ethereum: Optional[str] = None
     withdrawal_address_bitcoin: Optional[str] = None
-    treasury_fee_percent: Optional[float] = Field(None, ge=0, le=50)
+    treasury_fee_percent: Optional[float] = Field(None, ge=1, le=50)  # Min 1% — cannot disable treasury fee
     auto_sweep_enabled: Optional[bool] = None
     auto_sweep_threshold_sol: Optional[float] = Field(None, ge=0)
     auto_sweep_threshold_eth: Optional[float] = Field(None, ge=0)
@@ -202,8 +210,11 @@ async def ows_wallet_health() -> Dict[str, Any]:
 
 
 @router.post("/create", response_model=CreateWalletResponse)
-async def create_wallet(body: CreateWalletRequest) -> CreateWalletResponse:
-    """Create a new OWS wallet for an agent."""
+async def create_wallet(
+    body: CreateWalletRequest,
+    ceo: str = Depends(_require_ceo_auth_dep),
+) -> CreateWalletResponse:
+    """Create a new OWS wallet for an agent. CEO only — internal agents are provisioned by the system."""
     agent = _get_ows_agent()
     if not agent:
         raise HTTPException(status_code=503, detail="OWS wallet system unavailable")
@@ -234,8 +245,10 @@ async def create_wallet(body: CreateWalletRequest) -> CreateWalletResponse:
 
 
 @router.get("/{agent_id}")
-async def get_wallet_info(agent_id: str) -> Dict[str, Any]:
-    """Get full wallet info for an agent."""
+async def get_wallet_info(agent_id: str, caller: str = Depends(_require_agent_auth)) -> Dict[str, Any]:
+    """Get full wallet info. Agents can only view their own wallet."""
+    if caller != agent_id:
+        raise HTTPException(status_code=403, detail="You can only view your own wallet")
     agent = _get_ows_agent()
     if not agent:
         raise HTTPException(status_code=503, detail="OWS wallet system unavailable")
@@ -247,8 +260,10 @@ async def get_wallet_info(agent_id: str) -> Dict[str, Any]:
 
 
 @router.get("/{agent_id}/balance", response_model=BalanceResponse)
-async def get_balance(agent_id: str) -> BalanceResponse:
-    """Get balance for an agent (on-chain + internal ledger)."""
+async def get_balance(agent_id: str, caller: str = Depends(_require_agent_auth)) -> BalanceResponse:
+    """Get balance. Agents can only check their own balance."""
+    if caller != agent_id:
+        raise HTTPException(status_code=403, detail="You can only view your own balance")
     agent = _get_ows_agent()
     if not agent:
         raise HTTPException(status_code=503, detail="OWS wallet system unavailable")
@@ -261,8 +276,12 @@ async def get_balance(agent_id: str) -> BalanceResponse:
 
 
 @router.post("/transfer", response_model=TransferResponse)
-async def transfer(body: TransferRequest) -> TransferResponse:
-    """Internal agent-to-agent transfer with 5% treasury fee."""
+async def transfer(body: TransferRequest, caller: str = Depends(_require_agent_auth)) -> TransferResponse:
+    """Internal agent-to-agent transfer with 5% treasury fee. You can only send FROM your own wallet."""
+    if caller != body.from_agent_id:
+        raise HTTPException(status_code=403, detail="You can only transfer from your own wallet")
+    if body.from_agent_id == body.to_agent_id:
+        raise HTTPException(status_code=400, detail="Cannot transfer to yourself")
     agent = _get_ows_agent()
     if not agent:
         raise HTTPException(status_code=503, detail="OWS wallet system unavailable")
@@ -293,9 +312,13 @@ async def transfer(body: TransferRequest) -> TransferResponse:
 
 @router.get("/{agent_id}/history")
 async def get_transaction_history(
-    agent_id: str, limit: int = 50, offset: int = 0
+    agent_id: str, limit: int = 50, offset: int = 0, caller: str = Depends(_require_agent_auth)
 ) -> Dict[str, Any]:
-    """Get transaction history for an agent."""
+    """Get transaction history. Agents can only view their own."""
+    if caller != agent_id:
+        raise HTTPException(status_code=403, detail="You can only view your own history")
+    limit = min(limit, 200)  # Cap to prevent DB abuse
+    offset = max(offset, 0)
     mindex = _get_mindex()
     if not mindex:
         raise HTTPException(status_code=503, detail="Database unavailable")
@@ -349,8 +372,8 @@ async def get_transaction_history(
 
 
 @router.post("/sign")
-async def sign_transaction(body: SignRequest) -> Dict[str, Any]:
-    """Sign a transaction for an agent."""
+async def sign_transaction(body: SignRequest, ceo: str = Depends(_require_ceo_auth_dep)) -> Dict[str, Any]:
+    """Sign a transaction for an agent. CEO only — signing is never exposed to external agents."""
     agent = _get_ows_agent()
     if not agent:
         raise HTTPException(status_code=503, detail="OWS wallet system unavailable")
@@ -469,7 +492,7 @@ async def get_treasury_status() -> TreasuryResponse:
             by_agent_breakdown=by_agent,
             by_chain_breakdown=by_chain,
             supported_chains=[CHAIN_DISPLAY_NAMES.get(c, c) for c in SUPPORTED_CHAINS],
-            withdrawal_addresses=withdrawal_addrs,
+            withdrawal_addresses={},  # REDACTED from public endpoint — visible only in /treasury/settings (CEO auth)
             treasury_fee_percent=fee_pct,
         )
     except Exception as e:
@@ -510,8 +533,17 @@ async def init_treasury_auth(body: InitAuthRequest, request: Request) -> Dict[st
 
     ip = _get_client_ip(request)
 
-    # If key already exists, require the current key to rotate
+    # SECURITY: First-time init must come from internal network to prevent race condition
     existing_hash = await _get_ceo_key_hash()
+    if not existing_hash:
+        internal_prefixes = ("127.0.0.1", "::1", "192.168.0.", "10.", "172.16.")
+        if not any(ip.startswith(p) for p in internal_prefixes):
+            await _record_audit("init_auth_blocked_external", False, ip)
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="First-time key setup must be done from the internal network",
+            )
+
     if existing_hash:
         old_key = request.headers.get("x-treasury-key", "").strip()
         if not old_key or _hash_key(old_key) != existing_hash:
@@ -1043,8 +1075,10 @@ async def onboard_agent_wallet(body: OnboardWalletRequest) -> Dict[str, Any]:
 
 
 @router.post("/fund", response_model=FundResponse)
-async def get_fund_address(body: FundRequest) -> FundResponse:
-    """Get deposit address for funding a wallet."""
+async def get_fund_address(body: FundRequest, caller: str = Depends(_require_agent_auth)) -> FundResponse:
+    """Get deposit address for funding a wallet. You can only get your own."""
+    if caller != body.agent_id:
+        raise HTTPException(status_code=403, detail="You can only get your own deposit address")
     from mycosoft_mas.integrations.ows_client import CHAIN_ALIASES, CHAIN_DISPLAY_NAMES
 
     mindex = _get_mindex()
@@ -1117,8 +1151,10 @@ async def get_funding_status(tx_id: str) -> Dict[str, Any]:
 
 
 @router.post("/pay")
-async def pay_for_service(body: PayRequest) -> Dict[str, Any]:
-    """Pay for an API service from wallet (debits agent, credits treasury)."""
+async def pay_for_service(body: PayRequest, caller: str = Depends(_require_agent_auth)) -> Dict[str, Any]:
+    """Pay for an API service from wallet. You can only pay from your own wallet."""
+    if caller != body.agent_id:
+        raise HTTPException(status_code=403, detail="You can only pay from your own wallet")
     from mycosoft_mas.agents.crypto.ows_wallet_agent import TREASURY_AGENT_ID
 
     agent = _get_ows_agent()

--- a/mycosoft_mas/raas/onboarding.py
+++ b/mycosoft_mas/raas/onboarding.py
@@ -15,7 +15,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from mycosoft_mas.integrations.mindex_client import MINDEXClient
 from mycosoft_mas.raas import credits as credit_system
@@ -132,12 +132,24 @@ async def register_agent(body: AgentRegistration) -> AgentRegistrationResponse:
 
 
 @router.post("/activate")
-async def activate_agent(agent_id: str) -> Dict[str, Any]:
+async def activate_agent(agent_id: str, request: Request = None) -> Dict[str, Any]:
     """Activate an agent after signup payment is confirmed.
 
-    Called internally by payment webhook / crypto verification.
+    INTERNAL ONLY — called by payment webhook / crypto verification.
     Adds 100 bonus credits on activation.
+    Rejects calls that don't originate from localhost or internal IPs.
     """
+    # SECURITY: Only internal callers (webhooks from our own servers) may activate
+    if request and request.client:
+        client_ip = request.client.host
+        forwarded = (request.headers.get("x-forwarded-for") or "").split(",")[0].strip()
+        caller_ip = forwarded or client_ip
+        internal_prefixes = ("127.0.0.1", "::1", "192.168.0.", "10.", "172.16.")
+        if not any(caller_ip.startswith(p) for p in internal_prefixes):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Activation is internal only — called by payment webhooks",
+            )
     await _ensure_agents_table()
     now = datetime.now(timezone.utc).replace(tzinfo=None)
 

--- a/mycosoft_mas/security/treasury_auth.py
+++ b/mycosoft_mas/security/treasury_auth.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
 # Replay window: signatures older than this are rejected
 SIGNATURE_MAX_AGE_SECONDS = 300  # 5 minutes
 
+# Brute force protection: max failed attempts per IP before lockout
+MAX_FAILED_ATTEMPTS = 5
+LOCKOUT_SECONDS = 900  # 15 minutes
+_failed_attempts: Dict[str, list] = {}  # ip -> [timestamps of failures]
+
 # Config keys in ows_treasury_config
 CEO_KEY_HASH_CONFIG = "ceo_master_key_hash"
 ADDRESS_COOLDOWN_HOURS_CONFIG = "address_change_cooldown_hours"
@@ -153,6 +158,18 @@ async def require_ceo_auth(request: Request) -> str:
     """
     ip = _get_client_ip(request)
 
+    # Brute force protection — check if this IP is locked out
+    now_ts = time.time()
+    if ip in _failed_attempts:
+        # Prune old entries
+        _failed_attempts[ip] = [t for t in _failed_attempts[ip] if now_ts - t < LOCKOUT_SECONDS]
+        if len(_failed_attempts[ip]) >= MAX_FAILED_ATTEMPTS:
+            await _record_audit("auth_locked_out", False, ip, {"attempts": len(_failed_attempts[ip])})
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=f"Too many failed attempts. Locked out for {LOCKOUT_SECONDS // 60} minutes.",
+            )
+
     # Check if CEO key is configured at all
     stored_hash = await _get_ceo_key_hash()
     if not stored_hash:
@@ -169,10 +186,12 @@ async def require_ceo_auth(request: Request) -> str:
             await _record_audit("auth_success", True, ip, {"method": "direct_key"})
             return "ceo"
         else:
-            await _record_audit("auth_failure", False, ip, {"method": "direct_key"})
+            _failed_attempts.setdefault(ip, []).append(time.time())
+            remaining = MAX_FAILED_ATTEMPTS - len(_failed_attempts.get(ip, []))
+            await _record_audit("auth_failure", False, ip, {"method": "direct_key", "attempts_remaining": remaining})
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Invalid treasury key",
+                detail=f"Invalid treasury key. {max(remaining, 0)} attempts remaining before lockout.",
             )
 
     # Method 2: HMAC signature (replay-resistant)


### PR DESCRIPTION
CRITICAL fixes:
- All wallet endpoints now require RaaS API key auth (X-API-Key)
- Agents can only access their OWN wallet/balance/history (IDOR fix)
- Transfer endpoint enforces caller == from_agent_id (no stealing)
- Sign endpoint restricted to CEO-only (no arbitrary signing)
- Fund_wallet requires verified=True flag (no fake balance credits)
- Activate endpoint restricted to internal network IPs only

HIGH fixes:
- init-auth first-time setup restricted to internal network (race fix)
- Brute force protection: 5 attempts then 15-min IP lockout
- Treasury fee minimum 1% (cannot be set to 0 to skip cuts)

MEDIUM fixes:
- Treasury status endpoint no longer leaks withdrawal addresses
- Self-transfer blocked (prevents fake transaction records)
- Transfer/pay amounts capped (min dust threshold, max 1M sanity)
- History limit capped at 200 to prevent DB abuse
- All string fields have max_length constraints

## Summary by Sourcery

Harden wallet and treasury security by enforcing authenticated, scoped access to sensitive endpoints, tightening monetary and string input bounds, and adding protections against brute force and internal race-condition attacks.

New Features:
- Require RaaS API key authentication for agent-facing wallet operations and scope access so agents can only act on their own wallets.
- Enforce CEO-only access for wallet creation and transaction signing, and restrict agent activation to internal network callers only.

Bug Fixes:
- Prevent insecure indirect object access by blocking agents from viewing or manipulating other agents’ wallets, balances, histories, or funding endpoints.
- Ensure transfers cannot be initiated from another agent’s wallet, forbid self-transfers, and require verification flags and transaction hashes for funding credits to prevent fraudulent balance increases.
- Block external first-time treasury key initialization to eliminate race conditions and restrict master key setup to internal network IPs.
- Hide treasury withdrawal addresses from the public status endpoint to avoid leaking sensitive destination information.

Enhancements:
- Introduce brute-force protection for CEO auth with per-IP attempt tracking and temporary lockouts after repeated failures.
- Constrain transfer and payment amounts with minimum dust thresholds and upper sanity caps, and cap transaction history page sizes to reduce abuse and load.
- Tighten validation on string identifiers and names with maximum length limits and enforce a nonzero minimum treasury fee percentage to avoid disabling fee collection.