### PR TITLE
fix(consciousness): fix silent sensor collapse and add lifecycle management

### DIFF
--- a/mycosoft_mas/consciousness/core.py
+++ b/mycosoft_mas/consciousness/core.py
@@ -251,6 +251,7 @@ class MYCAConsciousness:
         self._intuition = IntuitionEngine(self)
         self._dream_state = DreamState(self)
         self._world_model = WorldModel(self)
+        await self._world_model.initialize_sensors()
         self._world_model.start_write_queue()
         self._voice_interface = VoiceInterface(self)
 

--- a/mycosoft_mas/consciousness/sensors/__init__.py
+++ b/mycosoft_mas/consciousness/sensors/__init__.py
@@ -3,19 +3,58 @@ MYCA World Sensors
 
 Sensors that feed the world model with data from various sources.
 
+Per-sensor try/except so one missing module doesn't collapse all sensors.
+
 Author: Morgan Rockwell / MYCA
 Created: February 10, 2026
 """
 
 from mycosoft_mas.consciousness.sensors.base_sensor import BaseSensor, SensorStatus
-from mycosoft_mas.consciousness.sensors.crep_sensor import CREPSensor
-from mycosoft_mas.consciousness.sensors.earth2_sensor import Earth2Sensor
-from mycosoft_mas.consciousness.sensors.earthlive_sensor import EarthLIVESensor
-from mycosoft_mas.consciousness.sensors.mindex_sensor import MINDEXSensor
-from mycosoft_mas.consciousness.sensors.mycobrain_sensor import MycoBrainSensor
-from mycosoft_mas.consciousness.sensors.natureos_sensor import NatureOSSensor
-from mycosoft_mas.consciousness.sensors.nlm_sensor import NLMSensor
-from mycosoft_mas.consciousness.sensors.workspace_sensor import WorkspaceSensor
+
+try:
+    from mycosoft_mas.consciousness.sensors.crep_sensor import CREPSensor
+except Exception:
+    CREPSensor = None  # type: ignore[assignment,misc]
+
+try:
+    from mycosoft_mas.consciousness.sensors.earth2_sensor import Earth2Sensor
+except Exception:
+    Earth2Sensor = None  # type: ignore[assignment,misc]
+
+try:
+    from mycosoft_mas.consciousness.sensors.earthlive_sensor import EarthLIVESensor
+except Exception:
+    EarthLIVESensor = None  # type: ignore[assignment,misc]
+
+try:
+    from mycosoft_mas.consciousness.sensors.mindex_sensor import MINDEXSensor
+except Exception:
+    MINDEXSensor = None  # type: ignore[assignment,misc]
+
+try:
+    from mycosoft_mas.consciousness.sensors.mycobrain_sensor import MycoBrainSensor
+except Exception:
+    MycoBrainSensor = None  # type: ignore[assignment,misc]
+
+try:
+    from mycosoft_mas.consciousness.sensors.natureos_sensor import NatureOSSensor
+except Exception:
+    NatureOSSensor = None  # type: ignore[assignment,misc]
+
+try:
+    from mycosoft_mas.consciousness.sensors.nlm_sensor import NLMSensor
+except Exception:
+    NLMSensor = None  # type: ignore[assignment,misc]
+
+try:
+    from mycosoft_mas.consciousness.sensors.workspace_sensor import WorkspaceSensor
+except Exception:
+    WorkspaceSensor = None  # type: ignore[assignment,misc]
+
+try:
+    from mycosoft_mas.consciousness.sensors.presence_sensor import PresenceSensor
+except Exception:
+    PresenceSensor = None  # type: ignore[assignment,misc]
 
 __all__ = [
     "BaseSensor",
@@ -28,4 +67,5 @@ __all__ = [
     "NLMSensor",
     "EarthLIVESensor",
     "WorkspaceSensor",
+    "PresenceSensor",
 ]

--- a/mycosoft_mas/consciousness/sensors/crep_sensor.py
+++ b/mycosoft_mas/consciousness/sensors/crep_sensor.py
@@ -15,6 +15,7 @@ Created: February 10, 2026
 """
 
 import logging
+import os
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -36,9 +37,9 @@ class CREPSensor(BaseSensor):
     global situational awareness data.
     """
 
-    # API endpoints
-    CREP_API_BASE = "http://192.168.0.187:3000/api/crep"
-    FALLBACK_API_BASE = "http://localhost:3010/api/crep"
+    # API endpoints (env-configurable)
+    CREP_API_BASE = os.getenv("MYCA_CREP_URL", "http://192.168.0.187:3000/api/crep")
+    FALLBACK_API_BASE = os.getenv("MYCA_CREP_FALLBACK_URL", "http://localhost:3010/api/crep")
     # Legacy aliases used by tests/older code.
     CREP_API = CREP_API_BASE
     MAS_API = CREP_API_BASE

--- a/mycosoft_mas/consciousness/sensors/earth2_sensor.py
+++ b/mycosoft_mas/consciousness/sensors/earth2_sensor.py
@@ -12,6 +12,7 @@ Created: February 10, 2026
 """
 
 import logging
+import os
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -33,9 +34,9 @@ class Earth2Sensor(BaseSensor):
     weather forecasting, climate predictions, and spore dispersal models.
     """
 
-    # API endpoints
-    EARTH2_API_BASE = "http://192.168.0.188:8001/api/earth2"
-    LOCAL_API_BASE = "http://localhost:8220"  # Local GPU service
+    # API endpoints (env-configurable)
+    EARTH2_API_BASE = os.getenv("MYCA_EARTH2_URL", "http://192.168.0.188:8001/api/earth2")
+    LOCAL_API_BASE = os.getenv("MYCA_EARTH2_LOCAL_URL", "http://localhost:8220")
 
     def __init__(self, world_model: Optional["WorldModel"] = None):
         super().__init__(world_model, "earth2")

--- a/mycosoft_mas/consciousness/sensors/mindex_sensor.py
+++ b/mycosoft_mas/consciousness/sensors/mindex_sensor.py
@@ -12,6 +12,7 @@ Created: February 10, 2026
 """
 
 import logging
+import os
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -33,9 +34,9 @@ class MINDEXSensor(BaseSensor):
     research data, and telemetry.
     """
 
-    # API endpoints
-    MINDEX_API_BASE = "http://192.168.0.189:8000"
-    FALLBACK_API_BASE = "http://192.168.0.188:8001/api/mindex"
+    # API endpoints (env-configurable)
+    MINDEX_API_BASE = os.getenv("MYCA_MINDEX_URL", "http://192.168.0.189:8000")
+    FALLBACK_API_BASE = os.getenv("MYCA_MINDEX_FALLBACK_URL", "http://192.168.0.188:8001/api/mindex")
 
     def __init__(self, world_model: Optional["WorldModel"] = None):
         super().__init__(world_model, "mindex")

--- a/mycosoft_mas/consciousness/sensors/mycobrain_sensor.py
+++ b/mycosoft_mas/consciousness/sensors/mycobrain_sensor.py
@@ -12,6 +12,7 @@ Created: February 10, 2026
 """
 
 import logging
+import os
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -33,9 +34,9 @@ class MycoBrainSensor(BaseSensor):
     data, sensor readings, and presence detection.
     """
 
-    # API endpoints
-    MYCOBRAIN_API_BASE = "http://192.168.0.188:8001/api/mycobrain"
-    LOCAL_SERVICE = "http://localhost:8003"  # Local MycoBrain service
+    # API endpoints (env-configurable)
+    MYCOBRAIN_API_BASE = os.getenv("MYCA_MYCOBRAIN_URL", "http://192.168.0.188:8001/api/mycobrain")
+    LOCAL_SERVICE = os.getenv("MYCA_MYCOBRAIN_LOCAL_URL", "http://localhost:8003")
 
     def __init__(self, world_model: Optional["WorldModel"] = None):
         super().__init__(world_model, "mycobrain")

--- a/mycosoft_mas/consciousness/sensors/natureos_sensor.py
+++ b/mycosoft_mas/consciousness/sensors/natureos_sensor.py
@@ -12,6 +12,7 @@ Created: February 10, 2026
 """
 
 import logging
+import os
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -33,8 +34,8 @@ class NatureOSSensor(BaseSensor):
     device status, and ecosystem health data.
     """
 
-    # API endpoints
-    NATUREOS_API_BASE = "http://192.168.0.188:8001/api/natureos"
+    # API endpoints (env-configurable)
+    NATUREOS_API_BASE = os.getenv("MYCA_NATUREOS_URL", "http://192.168.0.188:8001/api/natureos")
 
     def __init__(self, world_model: Optional["WorldModel"] = None):
         super().__init__(world_model, "natureos")

--- a/mycosoft_mas/consciousness/sensors/presence_sensor.py
+++ b/mycosoft_mas/consciousness/sensors/presence_sensor.py
@@ -1,0 +1,155 @@
+"""
+Presence Sensor
+
+Reads presence data from the Mycosoft website:
+- Online users count
+- Active sessions
+- Staff online
+- Superuser presence
+- Session statistics
+
+Author: MYCA
+Created: March 28, 2026
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+import httpx
+
+from mycosoft_mas.consciousness.sensors.base_sensor import BaseSensor
+
+if TYPE_CHECKING:
+    from mycosoft_mas.consciousness.world_model import SensorReading, WorldModel
+
+logger = logging.getLogger(__name__)
+
+
+class PresenceSensor(BaseSensor):
+    """
+    Sensor for user presence data.
+
+    Connects to the presence API to get real-time information about
+    online users, active sessions, staff presence, and site statistics.
+    """
+
+    # API endpoints (env-configurable)
+    PRESENCE_API_BASE = os.getenv("MYCA_PRESENCE_URL", "http://192.168.0.187:3000/api/presence")
+    FALLBACK_API_BASE = os.getenv(
+        "MYCA_PRESENCE_FALLBACK_URL", "http://localhost:3010/api/presence"
+    )
+
+    def __init__(self, world_model: Optional["WorldModel"] = None):
+        super().__init__(world_model, "presence")
+        self._client: Optional[httpx.AsyncClient] = None
+        self._api_base = self.PRESENCE_API_BASE
+
+    async def connect(self) -> bool:
+        """Connect to the Presence API."""
+        try:
+            self._client = httpx.AsyncClient(timeout=5.0)
+
+            # Try primary endpoint
+            try:
+                response = await self._client.get(f"{self.PRESENCE_API_BASE}/health")
+                if response.status_code == 200:
+                    self._api_base = self.PRESENCE_API_BASE
+                    self._mark_connected()
+                    return True
+            except Exception:
+                pass
+
+            # Try fallback
+            try:
+                response = await self._client.get(f"{self.FALLBACK_API_BASE}/health")
+                if response.status_code == 200:
+                    self._api_base = self.FALLBACK_API_BASE
+                    self._mark_connected()
+                    return True
+            except Exception:
+                pass
+
+            self._mark_error("Could not connect to Presence API")
+            return False
+
+        except Exception as e:
+            self._mark_error(str(e))
+            return False
+
+    async def disconnect(self) -> None:
+        """Disconnect from the Presence API."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+        self._mark_disconnected()
+
+    async def read(self) -> Optional[Dict[str, Any]]:
+        """Read current presence data.
+
+        Returns a plain dict (not SensorReading) for lightweight consumption
+        by WorldModel.update() and update_all().
+        """
+        if not self._client:
+            await self.connect()
+
+        if not self.is_connected:
+            return None
+
+        try:
+            data: Dict[str, Any] = {}
+
+            # Get online users summary
+            summary = await self._get_summary()
+            if summary:
+                data.update(summary)
+
+            # Get session stats
+            sessions = await self._get_sessions()
+            if sessions:
+                data["sessions"] = sessions
+                data["sessions_count"] = sessions.get("active", 0)
+
+            # Get staff status
+            staff = await self._get_staff()
+            if staff:
+                data["staff"] = staff
+                data["staff_count"] = staff.get("online_count", 0)
+                data["superuser_online"] = staff.get("superuser_online", False)
+
+            return data if data else None
+
+        except Exception as e:
+            self._mark_error(str(e))
+            return None
+
+    async def _get_summary(self) -> Optional[Dict[str, Any]]:
+        """Get online users summary."""
+        try:
+            response = await self._client.get(f"{self._api_base}/summary")
+            if response.status_code == 200:
+                return response.json()
+        except Exception as e:
+            logger.debug(f"Presence summary error: {e}")
+        return None
+
+    async def _get_sessions(self) -> Optional[Dict[str, Any]]:
+        """Get active session stats."""
+        try:
+            response = await self._client.get(f"{self._api_base}/sessions")
+            if response.status_code == 200:
+                return response.json()
+        except Exception as e:
+            logger.debug(f"Presence sessions error: {e}")
+        return None
+
+    async def _get_staff(self) -> Optional[Dict[str, Any]]:
+        """Get staff presence info."""
+        try:
+            response = await self._client.get(f"{self._api_base}/staff")
+            if response.status_code == 200:
+                return response.json()
+        except Exception as e:
+            logger.debug(f"Presence staff error: {e}")
+        return None

--- a/mycosoft_mas/consciousness/world_model.py
+++ b/mycosoft_mas/consciousness/world_model.py
@@ -203,6 +203,21 @@ class WorldState:
         return "; ".join(parts) if parts else "World state: limited data available"
 
 
+class _NullSensor:
+    """Stub sensor used when a real sensor fails to import."""
+
+    status = "unavailable"
+
+    async def connect(self) -> bool:
+        return False
+
+    async def read(self) -> Dict[str, Any]:
+        return {}
+
+    async def disconnect(self) -> None:
+        pass
+
+
 class WorldModel:
     """
     MYCA's unified world perception.
@@ -221,6 +236,19 @@ class WorldModel:
     EARTHLIVE_UPDATE_INTERVAL = 120
     PRESENCE_UPDATE_INTERVAL = 5
 
+    # All sensor keys in canonical order
+    _SENSOR_KEYS = (
+        "crep",
+        "earth2",
+        "natureos",
+        "mindex",
+        "mycobrain",
+        "nlm",
+        "earthlive",
+        "presence",
+        "workspace",
+    )
+
     def __init__(self, consciousness: Optional["MYCAConsciousness"] = None):
         self._consciousness = consciousness
         self._current_state = WorldState()
@@ -229,62 +257,19 @@ class WorldModel:
         self._cache_updated: datetime = datetime.now(timezone.utc)
         self._write_queue = WriteBehindQueue()
 
-        # Legacy/test compatibility: simple sensor registry.
-        self._sensors: Dict[str, Any] = {}
-        try:
-            from mycosoft_mas.consciousness.sensors import (
-                CREPSensor,
-                Earth2Sensor,
-                EarthLIVESensor,
-                MINDEXSensor,
-                MycoBrainSensor,
-                NatureOSSensor,
-                NLMSensor,
-                PresenceSensor,
-            )
+        # Build the unified sensor registry (per-sensor error isolation)
+        self._sensors: Dict[str, Any] = self._build_sensor_registry()
 
-            self._sensors = {
-                "crep": CREPSensor(self),
-                "earth2": Earth2Sensor(self),
-                "natureos": NatureOSSensor(self),
-                "mindex": MINDEXSensor(self),
-                "mycobrain": MycoBrainSensor(self),
-                "nlm": NLMSensor(self),
-                "earthlive": EarthLIVESensor(self),
-                "presence": PresenceSensor(self),
-            }
-        except Exception:
-
-            class _NullSensor:
-                status = "unavailable"
-
-                async def connect(self) -> bool:
-                    return False
-
-                async def read(self) -> Dict[str, Any]:
-                    return {}
-
-            # Ensure legacy tests still see all sensor keys even when imports fail.
-            self._sensors = {
-                "crep": _NullSensor(),
-                "earth2": _NullSensor(),
-                "natureos": _NullSensor(),
-                "mindex": _NullSensor(),
-                "mycobrain": _NullSensor(),
-                "nlm": _NullSensor(),
-                "earthlive": _NullSensor(),
-                "presence": _NullSensor(),
-            }
-
-        # Sensors (lazy-loaded)
-        self._crep_sensor: Optional["CREPSensor"] = None
-        self._earth2_sensor: Optional["Earth2Sensor"] = None
-        self._natureos_sensor: Optional["NatureOSSensor"] = None
-        self._mindex_sensor: Optional["MINDEXSensor"] = None
-        self._mycobrain_sensor: Optional["MycoBrainSensor"] = None
-        self._nlm_sensor: Optional["NLMSensor"] = None
-        self._earthlive_sensor: Optional["EarthLIVESensor"] = None
-        self._presence_sensor: Optional["PresenceSensor"] = None
+        # Named refs populated from the same _sensors dict
+        self._crep_sensor = self._sensors.get("crep")
+        self._earth2_sensor = self._sensors.get("earth2")
+        self._natureos_sensor = self._sensors.get("natureos")
+        self._mindex_sensor = self._sensors.get("mindex")
+        self._mycobrain_sensor = self._sensors.get("mycobrain")
+        self._nlm_sensor = self._sensors.get("nlm")
+        self._earthlive_sensor = self._sensors.get("earthlive")
+        self._presence_sensor = self._sensors.get("presence")
+        self._workspace_sensor = self._sensors.get("workspace")
 
         # Timestamps for throttling
         self._last_crep_update: Optional[datetime] = None
@@ -297,35 +282,83 @@ class WorldModel:
         self._last_presence_update: Optional[datetime] = None
 
         self._lock = asyncio.Lock()
+        self._sensors_initialized = False
+
+    def _build_sensor_registry(self) -> Dict[str, Any]:
+        """Build sensor registry with per-sensor error isolation.
+
+        Each sensor is constructed inside its own try/except so one
+        missing or broken module does not collapse all sensors.
+        """
+        from mycosoft_mas.consciousness.sensors import (
+            CREPSensor,
+            Earth2Sensor,
+            EarthLIVESensor,
+            MINDEXSensor,
+            MycoBrainSensor,
+            NatureOSSensor,
+            NLMSensor,
+            PresenceSensor,
+            WorkspaceSensor,
+        )
+
+        sensor_classes = {
+            "crep": CREPSensor,
+            "earth2": Earth2Sensor,
+            "natureos": NatureOSSensor,
+            "mindex": MINDEXSensor,
+            "mycobrain": MycoBrainSensor,
+            "nlm": NLMSensor,
+            "earthlive": EarthLIVESensor,
+            "presence": PresenceSensor,
+            "workspace": WorkspaceSensor,
+        }
+
+        registry: Dict[str, Any] = {}
+        for name, cls in sensor_classes.items():
+            try:
+                if cls is not None:
+                    registry[name] = cls(self)
+                else:
+                    logger.warning("Sensor class %s is None (import failed), using NullSensor", name)
+                    registry[name] = _NullSensor()
+            except Exception as exc:
+                logger.warning("Failed to construct sensor %s: %s", name, exc)
+                registry[name] = _NullSensor()
+        return registry
 
     async def initialize_sensors(self) -> None:
-        """Initialize all world sensors."""
-        try:
-            from mycosoft_mas.consciousness.sensors import (
-                CREPSensor,
-                Earth2Sensor,
-                EarthLIVESensor,
-                MINDEXSensor,
-                MycoBrainSensor,
-                NatureOSSensor,
-                NLMSensor,
-                PresenceSensor,
-                WorkspaceSensor,
-            )
+        """Initialize all world sensors (idempotent).
 
-            self._crep_sensor = CREPSensor(self)
-            self._earth2_sensor = Earth2Sensor(self)
-            self._natureos_sensor = NatureOSSensor(self)
-            self._mindex_sensor = MINDEXSensor(self)
-            self._mycobrain_sensor = MycoBrainSensor(self)
-            self._nlm_sensor = NLMSensor(self)
-            self._earthlive_sensor = EarthLIVESensor(self)
-            self._presence_sensor = PresenceSensor(self)
-            self._workspace_sensor = WorkspaceSensor(self)
+        Rebuilds the sensor registry and syncs named refs.
+        Safe to call multiple times.
+        """
+        if self._sensors_initialized:
+            return
 
-            logger.info("World sensors initialized")
-        except ImportError as e:
-            logger.warning(f"Could not initialize some sensors: {e}")
+        # Rebuild registry so sensors constructed after __init__ pick up
+        # any newly available modules.
+        self._sensors = self._build_sensor_registry()
+
+        # Sync named refs from the same dict
+        self._crep_sensor = self._sensors.get("crep")
+        self._earth2_sensor = self._sensors.get("earth2")
+        self._natureos_sensor = self._sensors.get("natureos")
+        self._mindex_sensor = self._sensors.get("mindex")
+        self._mycobrain_sensor = self._sensors.get("mycobrain")
+        self._nlm_sensor = self._sensors.get("nlm")
+        self._earthlive_sensor = self._sensors.get("earthlive")
+        self._presence_sensor = self._sensors.get("presence")
+        self._workspace_sensor = self._sensors.get("workspace")
+
+        self._sensors_initialized = True
+        logger.info("World sensors initialized (%d sensors)", len(self._sensors))
+
+    @property
+    def is_degraded(self) -> bool:
+        """True when more than half of sensors are NullSensor stubs."""
+        null_count = sum(1 for s in self._sensors.values() if isinstance(s, _NullSensor))
+        return null_count > len(self._sensors) // 2
 
     async def initialize(self) -> None:
         """Legacy init: connect all sensors."""
@@ -807,8 +840,19 @@ class WorldModel:
         """Start write-behind processor loop."""
         self._write_queue.start()
 
+    async def disconnect_all(self) -> None:
+        """Disconnect all sensors that support it."""
+        for name, sensor in self._sensors.items():
+            disconnect = getattr(sensor, "disconnect", None)
+            if asyncio.iscoroutinefunction(disconnect):
+                try:
+                    await disconnect()
+                except Exception as exc:
+                    logger.debug("Error disconnecting sensor %s: %s", name, exc)
+
     async def shutdown(self) -> None:
-        """Shutdown background write queue."""
+        """Shutdown background write queue and disconnect sensors."""
+        await self.disconnect_all()
         await self._write_queue.stop()
 
     async def get_state(self) -> Dict[str, Any]:

--- a/mycosoft_mas/core/myca_main.py
+++ b/mycosoft_mas/core/myca_main.py
@@ -1689,6 +1689,16 @@ async def startup_event():
     except Exception as exc:
         logger.warning(f"Agent supervisor failed to start: {exc}")
 
+    # Awaken MYCA consciousness (starts world-model loop, pattern recognition, etc.)
+    try:
+        from mycosoft_mas.consciousness import get_consciousness
+
+        consciousness = get_consciousness()
+        await consciousness.awaken()
+        logger.info("✓ MYCA consciousness awakened")
+    except Exception as exc:
+        logger.warning(f"Consciousness awaken failed (non-fatal): {exc}")
+
     logger.info("✓ MAS ready - all agents operational 24/7")
 
 
@@ -1698,6 +1708,16 @@ async def shutdown_event():
     import logging
 
     logger = logging.getLogger("MAS_Shutdown")
+
+    # Hibernate MYCA consciousness (stops background loops, disconnects sensors)
+    try:
+        from mycosoft_mas.consciousness import get_consciousness
+
+        consciousness = get_consciousness()
+        await consciousness.hibernate()
+        logger.info("MYCA consciousness hibernated")
+    except Exception as exc:
+        logger.warning("Consciousness hibernate error: %s", exc)
     try:
         from mycosoft_mas.collectors import get_orchestrator
 

--- a/mycosoft_mas/core/routers/worldstate_api.py
+++ b/mycosoft_mas/core/routers/worldstate_api.py
@@ -17,6 +17,11 @@ from fastapi import APIRouter, Query
 router = APIRouter(prefix="/api/myca/world", tags=["worldstate", "myca"])
 
 
+def _freshness_val(f: Any) -> str:
+    """Extract freshness string from a DataFreshness enum (or return 'unavailable')."""
+    return getattr(f, "value", "unavailable") if f else "unavailable"
+
+
 def _get_world_model():
     """Get canonical WorldModel from consciousness. Returns None if unavailable."""
     try:
@@ -29,20 +34,30 @@ def _get_world_model():
 
 
 def _world_state_to_dict(state: Any) -> Dict[str, Any]:
-    """Serialize WorldState to API-safe dict."""
+    """Serialize WorldState to API-safe dict.
+
+    Wraps predictions, ecosystem, nlm, earthlive, and presence with
+    {data: ..., freshness: ...} for consistent per-sensor freshness.
+    """
     if state is None:
         return {}
     out: Dict[str, Any] = {
         "timestamp": getattr(state, "timestamp", None),
         "crep": {
             "data": getattr(state, "crep_data", {}) or {},
-            "freshness": getattr(getattr(state, "crep_freshness", None), "value", "unavailable"),
+            "freshness": _freshness_val(getattr(state, "crep_freshness", None)),
             "flights": getattr(state, "total_flights", 0),
             "vessels": getattr(state, "total_vessels", 0),
             "satellites": getattr(state, "total_satellites", 0),
         },
-        "predictions": getattr(state, "predictions", {}) or {},
-        "ecosystem": getattr(state, "ecosystem_status", {}) or {},
+        "predictions": {
+            "data": getattr(state, "predictions", {}) or {},
+            "freshness": _freshness_val(getattr(state, "predictions_freshness", None)),
+        },
+        "ecosystem": {
+            "data": getattr(state, "ecosystem_status", {}) or {},
+            "freshness": _freshness_val(getattr(state, "ecosystem_freshness", None)),
+        },
         "mindex": {
             "available": getattr(state, "knowledge_available", False),
             "stats": getattr(state, "knowledge_stats", {}) or {},
@@ -50,15 +65,22 @@ def _world_state_to_dict(state: Any) -> Dict[str, Any]:
         "devices": {
             "telemetry": getattr(state, "device_telemetry", {}) or {},
             "active_count": getattr(state, "active_devices", 0),
-            "freshness": getattr(getattr(state, "device_freshness", None), "value", "unavailable"),
+            "freshness": _freshness_val(getattr(state, "device_freshness", None)),
         },
-        "nlm": getattr(state, "nlm_insights", {}) or {},
-        "earthlive": getattr(state, "earthlive_packet", {}) or {},
+        "nlm": {
+            "data": getattr(state, "nlm_insights", {}) or {},
+            "freshness": _freshness_val(getattr(state, "nlm_freshness", None)),
+        },
+        "earthlive": {
+            "data": getattr(state, "earthlive_packet", {}) or {},
+            "freshness": _freshness_val(getattr(state, "earthlive_freshness", None)),
+        },
         "presence": {
             "online_users": getattr(state, "online_users", 0),
             "active_sessions": getattr(state, "active_sessions", 0),
             "staff_online": getattr(state, "staff_online", 0),
             "data": getattr(state, "presence_data", {}) or {},
+            "freshness": _freshness_val(getattr(state, "presence_freshness", None)),
         },
     }
     if hasattr(state, "timestamp") and state.timestamp:
@@ -96,7 +118,7 @@ async def get_world() -> Dict[str, Any]:
     return {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "world": world,
-        "degraded": False,
+        "degraded": getattr(wm, "is_degraded", False),
     }
 
 
@@ -122,7 +144,7 @@ async def get_world_summary() -> Dict[str, Any]:
     return {
         "summary": s if isinstance(s, str) else str(s),
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "degraded": False,
+        "degraded": getattr(wm, "is_degraded", False),
     }
 
 
@@ -153,7 +175,7 @@ async def get_world_region(
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "summary": summary_text,
         "world": _world_state_to_dict(state) if state else {},
-        "degraded": False,
+        "degraded": getattr(wm, "is_degraded", False),
         "region_requested": lat is not None and lon is not None,
     }
     if lat is not None and lon is not None:
@@ -187,9 +209,6 @@ async def get_world_sources() -> Dict[str, Any]:
             "sources": {},
             "detail": "No world state available.",
         }
-
-    def _freshness_val(f) -> str:
-        return getattr(f, "value", "unavailable") if f else "unavailable"
 
     sources: Dict[str, Any] = {
         "crep": {"freshness": _freshness_val(state.crep_freshness)},

--- a/tests/consciousness/test_world_model.py
+++ b/tests/consciousness/test_world_model.py
@@ -27,6 +27,40 @@ class TestWorldState:
         assert state.mindex_data == {}
         assert state.mycobrain_data == {}
 
+    def test_world_state_presence_defaults(self):
+        """WorldState presence fields should default correctly."""
+        from mycosoft_mas.consciousness.world_model import WorldState
+
+        state = WorldState()
+        assert state.presence_data == {}
+        assert state.online_users == 0
+        assert state.active_sessions == 0
+        assert state.staff_online == 0
+        assert state.superuser_online is False
+
+    def test_world_state_summary_empty(self):
+        """Empty world state should return 'limited data available'."""
+        from mycosoft_mas.consciousness.world_model import WorldState
+
+        state = WorldState()
+        assert "limited data available" in state.to_summary()
+
+    def test_world_state_summary_with_data(self):
+        """World state with data should produce a meaningful summary."""
+        from mycosoft_mas.consciousness.world_model import WorldState
+
+        state = WorldState()
+        state.crep_data = {"flights": []}
+        state.total_flights = 100
+        state.total_vessels = 50
+        state.total_satellites = 10
+        state.online_users = 5
+        state.staff_online = 2
+
+        summary = state.to_summary()
+        assert "100 flights" in summary
+        assert "5 users online" in summary
+
 
 class TestWorldModel:
     """Tests for WorldModel."""
@@ -39,6 +73,59 @@ class TestWorldModel:
 
         assert model._sensors is not None
         assert model._current_state is not None
+
+    def test_world_model_has_all_sensor_keys(self):
+        """WorldModel._sensors should contain all 9 canonical sensor keys."""
+        from mycosoft_mas.consciousness.world_model import WorldModel
+
+        model = WorldModel()
+
+        expected_keys = {
+            "crep", "earth2", "natureos", "mindex",
+            "mycobrain", "nlm", "earthlive", "presence", "workspace",
+        }
+        assert set(model._sensors.keys()) == expected_keys
+
+    def test_sensors_not_all_null_stubs(self):
+        """At least some sensors should be real, not all NullSensor."""
+        from mycosoft_mas.consciousness.world_model import WorldModel, _NullSensor
+
+        model = WorldModel()
+
+        null_count = sum(1 for s in model._sensors.values() if isinstance(s, _NullSensor))
+        # At least the sensors whose modules exist should be real
+        assert null_count < len(model._sensors), (
+            f"All {len(model._sensors)} sensors are NullSensor stubs — "
+            "per-sensor isolation is not working"
+        )
+
+    def test_named_sensor_refs_populated(self):
+        """Named refs (_crep_sensor, etc.) should be populated from _sensors."""
+        from mycosoft_mas.consciousness.world_model import WorldModel
+
+        model = WorldModel()
+
+        # Named refs should point to the same objects in _sensors
+        assert model._crep_sensor is model._sensors.get("crep")
+        assert model._earth2_sensor is model._sensors.get("earth2")
+        assert model._natureos_sensor is model._sensors.get("natureos")
+        assert model._mindex_sensor is model._sensors.get("mindex")
+        assert model._mycobrain_sensor is model._sensors.get("mycobrain")
+        assert model._nlm_sensor is model._sensors.get("nlm")
+        assert model._earthlive_sensor is model._sensors.get("earthlive")
+        assert model._presence_sensor is model._sensors.get("presence")
+        assert model._workspace_sensor is model._sensors.get("workspace")
+
+    @pytest.mark.asyncio
+    async def test_initialize_sensors_is_idempotent(self):
+        """Calling initialize_sensors twice should be safe."""
+        from mycosoft_mas.consciousness.world_model import WorldModel
+
+        model = WorldModel()
+        await model.initialize_sensors()
+        first_sensors = dict(model._sensors)
+        await model.initialize_sensors()  # second call — should be no-op
+        assert model._sensors == first_sensors
 
     @pytest.mark.asyncio
     async def test_initialize_sensors(self):
@@ -73,6 +160,47 @@ class TestWorldModel:
 
         # State should be updated
         assert model._current_state is not None
+
+    @pytest.mark.asyncio
+    async def test_update_all_populates_crep(self):
+        """update_all with CREP data should flow into current state."""
+        from mycosoft_mas.consciousness.world_model import WorldModel
+
+        model = WorldModel()
+
+        crep_data = {"flight_count": 42, "flights": []}
+        model._sensors["crep"].read = AsyncMock(return_value=crep_data)
+        # Make other sensors return empty
+        for name, sensor in model._sensors.items():
+            if name != "crep":
+                sensor.read = AsyncMock(return_value={})
+
+        await model.update_all()
+        assert model._current_state.crep_data == crep_data
+
+    @pytest.mark.asyncio
+    async def test_update_all_populates_presence(self):
+        """update_all with presence data should update presence fields."""
+        from mycosoft_mas.consciousness.world_model import WorldModel
+
+        model = WorldModel()
+
+        presence_data = {
+            "online_count": 7,
+            "sessions_count": 12,
+            "staff_count": 3,
+            "superuser_online": True,
+        }
+        model._sensors["presence"].read = AsyncMock(return_value=presence_data)
+        for name, sensor in model._sensors.items():
+            if name != "presence":
+                sensor.read = AsyncMock(return_value={})
+
+        await model.update_all()
+        assert model._current_state.online_users == 7
+        assert model._current_state.active_sessions == 12
+        assert model._current_state.staff_online == 3
+        assert model._current_state.superuser_online is True
 
     def test_get_current_state(self):
         """get_current_state should return WorldState."""
@@ -111,3 +239,164 @@ class TestWorldModel:
         assert isinstance(status, dict)
         assert "crep" in status
         assert "earth2" in status
+
+
+class TestWorldModelDegradation:
+    """Tests for the is_degraded property."""
+
+    def test_not_degraded_when_sensors_available(self):
+        """is_degraded should be False when most sensors are real."""
+        from mycosoft_mas.consciousness.world_model import WorldModel
+
+        model = WorldModel()
+        assert model.is_degraded is False
+
+    def test_degraded_when_all_null(self):
+        """is_degraded should be True when all sensors are NullSensor."""
+        from mycosoft_mas.consciousness.world_model import WorldModel, _NullSensor
+
+        model = WorldModel()
+        # Replace all sensors with NullSensor
+        for key in list(model._sensors.keys()):
+            model._sensors[key] = _NullSensor()
+
+        assert model.is_degraded is True
+
+    def test_degraded_when_majority_null(self):
+        """is_degraded should be True when more than half are NullSensor."""
+        from mycosoft_mas.consciousness.world_model import WorldModel, _NullSensor
+
+        model = WorldModel()
+        keys = list(model._sensors.keys())
+        majority = len(keys) // 2 + 1
+        for key in keys[:majority]:
+            model._sensors[key] = _NullSensor()
+
+        assert model.is_degraded is True
+
+    def test_not_degraded_when_minority_null(self):
+        """is_degraded should be False when less than half are NullSensor."""
+        from mycosoft_mas.consciousness.world_model import WorldModel, _NullSensor
+
+        model = WorldModel()
+        keys = list(model._sensors.keys())
+        # Replace only 2 sensors
+        for key in keys[:2]:
+            model._sensors[key] = _NullSensor()
+
+        assert model.is_degraded is False
+
+    def test_is_degraded_initially_false(self):
+        """Fresh WorldModel with working imports should not be degraded."""
+        from mycosoft_mas.consciousness.world_model import WorldModel
+
+        model = WorldModel()
+        assert model.is_degraded is False
+
+
+class TestPresenceSensor:
+    """Tests for PresenceSensor."""
+
+    def test_presence_sensor_importable(self):
+        """PresenceSensor should be importable."""
+        from mycosoft_mas.consciousness.sensors.presence_sensor import PresenceSensor
+        assert PresenceSensor is not None
+
+    def test_presence_sensor_init(self):
+        """PresenceSensor should construct without a world model."""
+        from mycosoft_mas.consciousness.sensors.presence_sensor import PresenceSensor
+
+        sensor = PresenceSensor()
+        assert sensor.name == "presence"
+
+    @pytest.mark.asyncio
+    async def test_presence_sensor_read_when_disconnected(self):
+        """PresenceSensor.read() should return None when not connected."""
+        from mycosoft_mas.consciousness.sensors.base_sensor import SensorStatus
+        from mycosoft_mas.consciousness.sensors.presence_sensor import PresenceSensor
+
+        sensor = PresenceSensor()
+        sensor._client = None
+        sensor._status = SensorStatus.DISCONNECTED
+        result = await sensor.read()
+        assert result is None
+
+
+class TestWorldstateAPISerialization:
+    """Tests for worldstate_api serialization helpers.
+
+    Importing mycosoft_mas.core.routers triggers jose/JWT deps that may
+    not be present in lightweight test environments, so these tests skip
+    gracefully when the import chain is unavailable.
+    """
+
+    @staticmethod
+    def _import_worldstate_api():
+        """Try to import worldstate_api; return module or None."""
+        try:
+            from mycosoft_mas.core.routers import worldstate_api
+            return worldstate_api
+        except Exception:
+            return None
+
+    def test_freshness_val_with_enum(self):
+        """_freshness_val should extract .value from DataFreshness."""
+        mod = self._import_worldstate_api()
+        if mod is None:
+            pytest.skip("worldstate_api import chain unavailable (missing jose)")
+        from mycosoft_mas.consciousness.world_model import DataFreshness
+
+        assert mod._freshness_val(DataFreshness.LIVE) == "live"
+        assert mod._freshness_val(DataFreshness.UNAVAILABLE) == "unavailable"
+
+    def test_freshness_val_with_none(self):
+        """_freshness_val should return 'unavailable' for None."""
+        mod = self._import_worldstate_api()
+        if mod is None:
+            pytest.skip("worldstate_api import chain unavailable (missing jose)")
+
+        assert mod._freshness_val(None) == "unavailable"
+
+    def test_world_state_to_dict_includes_freshness(self):
+        """_world_state_to_dict should include freshness for predictions, ecosystem, etc."""
+        mod = self._import_worldstate_api()
+        if mod is None:
+            pytest.skip("worldstate_api import chain unavailable (missing jose)")
+        from mycosoft_mas.consciousness.world_model import WorldState
+
+        state = WorldState()
+        d = mod._world_state_to_dict(state)
+
+        # predictions and ecosystem should now be wrapped with freshness
+        assert "freshness" in d["predictions"]
+        assert "data" in d["predictions"]
+        assert "freshness" in d["ecosystem"]
+        assert "data" in d["ecosystem"]
+        assert "freshness" in d["nlm"]
+        assert "freshness" in d["earthlive"]
+        assert "freshness" in d["presence"]
+
+    def test_world_state_to_dict_none_returns_empty(self):
+        """_world_state_to_dict with None should return empty dict."""
+        mod = self._import_worldstate_api()
+        if mod is None:
+            pytest.skip("worldstate_api import chain unavailable (missing jose)")
+
+        assert mod._world_state_to_dict(None) == {}
+
+    def test_world_state_to_dict_crep_fields(self):
+        """_world_state_to_dict should include CREP flight/vessel/satellite counts."""
+        mod = self._import_worldstate_api()
+        if mod is None:
+            pytest.skip("worldstate_api import chain unavailable (missing jose)")
+        from mycosoft_mas.consciousness.world_model import WorldState
+
+        state = WorldState()
+        state.total_flights = 100
+        state.total_vessels = 50
+        state.total_satellites = 10
+
+        d = mod._world_state_to_dict(state)
+        assert d["crep"]["flights"] == 100
+        assert d["crep"]["vessels"] == 50
+        assert d["crep"]["satellites"] == 10


### PR DESCRIPTION
## Summary

- **Fixed silent sensor collapse**: A single missing `presence_sensor.py` was causing all 8 sensors to fall through a shared `try/except` and be replaced with `_NullSensor` stubs, making MYCA effectively blind. Now each sensor has isolated per-sensor error handling.
- **Unified dual sensor registries**: `WorldModel.__init__` built a `_sensors` dict while `initialize_sensors()` created separate `_crep_sensor`/`_earth2_sensor` attributes that never synced. Both now populate from the same `_build_sensor_registry()` method.
- **Added consciousness lifecycle**: `startup_event()` now calls `consciousness.awaken()` and `shutdown_event()` calls `consciousness.hibernate()`, so background loops (world-model, pattern recognition, dream) actually start.
- **Fixed false health reporting**: Worldstate API endpoints now use `wm.is_degraded` (true when >50% sensors are NullSensor stubs) instead of hardcoded `degraded: False`.
- **Added per-sensor freshness**: `_world_state_to_dict()` wraps `predictions`, `ecosystem`, `nlm`, `earthlive`, and `presence` with `{"data": ..., "freshness": ...}`.
- **Made sensor endpoints env-configurable**: All 6 sensors with hardcoded LAN IPs now read from `MYCA_*_URL` / `MYCA_*_FALLBACK_URL` env vars with existing IPs as defaults.
- **Created `PresenceSensor`**: New sensor for online users, sessions, staff, and superuser presence.
- **Expanded tests**: From 5 to 29 tests covering sensor registry integrity, presence sensor, degradation detection, serialization, and state structure. 109 passed, 66 skipped, 0 failed.

### Breaking change

`/api/myca/world` response shape changed for `predictions`, `ecosystem`, `nlm`, `earthlive`, and `presence` — they are now wrapped in `{"data": ..., "freshness": ...}`. Consumers reading `response["world"]["predictions"]` directly need `response["world"]["predictions"]["data"]` instead.

## Test plan

- [x] `pytest tests/consciousness/` — 109 passed, 66 skipped, 0 failed
- [ ] Deploy to staging and verify `/api/myca/world` returns `degraded: false`
- [ ] Verify `/api/myca/world/sources` shows per-sensor freshness cycling from `unavailable` to `live`/`recent`
- [ ] Confirm startup logs show `MYCA consciousness awakened`
- [ ] Verify no sensor cascade failures in logs after 5 minutes
- [ ] Test env-var overrides for at least one sensor endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve MYCA consciousness world model robustness, add presence sensing, expose per-sensor freshness in the worldstate API, and integrate lifecycle hooks into startup/shutdown.

New Features:
- Introduce a PresenceSensor for user, session, and staff presence data and integrate it into the world model.
- Expose per-sensor freshness metadata for predictions, ecosystem, NLP, earthlive, and presence in the worldstate API responses.

Bug Fixes:
- Prevent a single failing sensor import from collapsing the entire sensor registry by isolating sensor construction errors.
- Report world degradation status from the world model based on actual sensor health instead of a hardcoded false value.

Enhancements:
- Unify world model sensor management through a shared registry used by both internal references and initialization, and add a workspace sensor entry.
- Add an is_degraded property and graceful sensor disconnect logic to the world model shutdown path.
- Make sensor HTTP endpoints configurable via environment variables instead of hardcoded LAN URLs.
- Wire consciousness awaken/hibernate into application startup and shutdown to control background loops.

Tests:
- Expand world model, presence sensor, and worldstate API serialization tests, including degradation detection, sensor registry integrity, and response structure validation.