### PR TITLE
fix: enable RLS on 16 public tables to resolve Supabase security linter errors

### DIFF
--- a/docs/RLS_SECURITY_FIXES_APR07_2026.md
+++ b/docs/RLS_SECURITY_FIXES_APR07_2026.md
@@ -1,0 +1,57 @@
+# RLS Security Fixes — April 7, 2026
+
+## Summary
+
+Resolves 18 Supabase database linter errors across 3 categories:
+
+| Lint Code | Issue | Count |
+|-----------|-------|-------|
+| `0007_policy_exists_rls_disabled` | Tables have RLS policies but RLS not enabled | 2 |
+| `0013_rls_disabled_in_public` | Public tables without RLS | 16 |
+| `0023_sensitive_columns_exposed` | `myco_users.password` exposed via API | 1 |
+
+## Affected Tables (16)
+
+| Table | Had Policies? | New in This Migration? |
+|-------|--------------|----------------------|
+| `agent_incident_activity` | Yes | No (was in 005, RLS not applied) |
+| `incident_log_chain` | Yes | No (was in 005, RLS not applied) |
+| `myco_users` | No | No (was in 005, RLS not applied) |
+| `mushroom_discoveries` | No | No (was in 005, RLS not applied) |
+| `myco_transactions` | No | No (was in 005, RLS not applied) |
+| `lab_kit_requests` | No | No (was in 005, RLS not applied) |
+| `myco_leaderboard` | No | No (was in 005, RLS not applied) |
+| `myco_achievements` | No | No (was in 005, RLS not applied) |
+| `myco_location_cache` | No | No (was in 005, RLS not applied) |
+| `incident_causality` | No | No (was in 005, RLS not applied) |
+| `incident_chain_details` | No | No (was in 005, RLS not applied) |
+| `cascade_predictions` | No | No (was in 005, RLS not applied) |
+| `agent_resolutions` | No | No (was in 005, RLS not applied) |
+| `agent_run_log` | No | No (was in 005, RLS not applied) |
+| `system_status` | No | **Yes** |
+| `mycobrain_data` | No | **Yes** |
+
+## Changes Applied
+
+### 1. RLS Enabled + Forced
+All 16 tables get `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY`.
+
+### 2. Policies Created
+- **`service_role`**: Full access (`ALL`) on every table
+- **`authenticated`**: Read access (`SELECT`) on every table
+
+### 3. `myco_users` Password Protection
+- `REVOKE SELECT (password)` from `anon` and `authenticated` roles
+- Created `public.myco_users_safe` view excluding the password column
+
+## How to Apply
+
+Run against the Supabase/PostgreSQL database on MINDEX (192.168.0.189:5432):
+
+```bash
+psql -h 192.168.0.189 -U postgres -d mycosoft -f migrations/029_enable_rls_security_fixes_APR07_2026.sql
+```
+
+## Verification
+
+After applying, re-run the Supabase linter. All 18 errors should be resolved.

--- a/migrations/029_enable_rls_security_fixes_APR07_2026.sql
+++ b/migrations/029_enable_rls_security_fixes_APR07_2026.sql
@@ -1,0 +1,156 @@
+-- Enable RLS Security Fixes - April 7, 2026
+-- Resolves Supabase linter errors:
+--   0007_policy_exists_rls_disabled: Tables with policies but RLS not enabled
+--   0013_rls_disabled_in_public: Public tables without RLS
+--   0023_sensitive_columns_exposed: myco_users.password exposed without RLS
+--
+-- All 16 affected tables get RLS enabled + service_role full access + authenticated read.
+-- myco_users additionally gets column-level protection: the password column is
+-- revoked from anon/authenticated and a secure view is provided.
+
+BEGIN;
+
+-- ============================================================================
+-- 1. Enable RLS on every affected table
+-- ============================================================================
+
+ALTER TABLE IF EXISTS public.agent_incident_activity  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.incident_log_chain        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_users                ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.mushroom_discoveries      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_transactions         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.lab_kit_requests          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_leaderboard          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_achievements         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_location_cache       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.incident_causality        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.incident_chain_details    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.cascade_predictions       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.agent_resolutions         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.agent_run_log             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.system_status             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.mycobrain_data            ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================================
+-- 2. Service-role full access policies (idempotent — skip if exists)
+-- ============================================================================
+
+DO $$
+DECLARE
+  tbl text;
+  pol text;
+BEGIN
+  FOREACH tbl IN ARRAY ARRAY[
+    'agent_incident_activity',
+    'incident_log_chain',
+    'myco_users',
+    'mushroom_discoveries',
+    'myco_transactions',
+    'lab_kit_requests',
+    'myco_leaderboard',
+    'myco_achievements',
+    'myco_location_cache',
+    'incident_causality',
+    'incident_chain_details',
+    'cascade_predictions',
+    'agent_resolutions',
+    'agent_run_log',
+    'system_status',
+    'mycobrain_data'
+  ] LOOP
+    -- Service role: full access
+    pol := 'Allow service role all ' || tbl;
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = tbl AND policyname = pol
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY %I ON public.%I FOR ALL TO service_role USING (true) WITH CHECK (true)',
+        pol, tbl
+      );
+    END IF;
+
+    -- Authenticated: read access
+    pol := 'Allow authenticated read ' || tbl;
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = tbl AND policyname = pol
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY %I ON public.%I FOR SELECT TO authenticated USING (true)',
+        pol, tbl
+      );
+    END IF;
+  END LOOP;
+END $$;
+
+-- ============================================================================
+-- 3. myco_users: protect the password column from API exposure
+--    Revoke direct column access and provide a safe view.
+-- ============================================================================
+
+-- Revoke SELECT on the password column from public-facing roles
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'myco_users' AND column_name = 'password'
+  ) THEN
+    EXECUTE 'REVOKE SELECT (password) ON public.myco_users FROM anon, authenticated';
+  END IF;
+END $$;
+
+-- Create a safe view that excludes the password column
+CREATE OR REPLACE VIEW public.myco_users_safe AS
+  SELECT *
+  FROM public.myco_users;
+
+-- The view above uses SELECT * but the column-level REVOKE means anon/authenticated
+-- cannot read the password column through the table directly. For the view, we
+-- explicitly drop the password column:
+DROP VIEW IF EXISTS public.myco_users_safe;
+
+DO $$
+DECLARE
+  cols text;
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'myco_users'
+  ) THEN
+    SELECT string_agg(quote_ident(column_name), ', ')
+    INTO cols
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'myco_users'
+      AND column_name != 'password';
+
+    IF cols IS NOT NULL THEN
+      EXECUTE format('CREATE OR REPLACE VIEW public.myco_users_safe AS SELECT %s FROM public.myco_users', cols);
+      EXECUTE 'GRANT SELECT ON public.myco_users_safe TO authenticated';
+    END IF;
+  END IF;
+END $$;
+
+-- ============================================================================
+-- 4. Force-enable RLS for table owners too (prevents bypass by table owner)
+-- ============================================================================
+
+ALTER TABLE IF EXISTS public.agent_incident_activity  FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.incident_log_chain        FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_users                FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.mushroom_discoveries      FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_transactions         FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.lab_kit_requests          FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_leaderboard          FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_achievements         FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.myco_location_cache       FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.incident_causality        FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.incident_chain_details    FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.cascade_predictions       FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.agent_resolutions         FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.agent_run_log             FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.system_status             FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.mycobrain_data            FORCE ROW LEVEL SECURITY;
+
+COMMIT;


### PR DESCRIPTION
Addresses lints 0007 (policy_exists_rls_disabled), 0013 (rls_disabled_in_public),
and 0023 (sensitive_columns_exposed). Enables + forces RLS, creates service_role
and authenticated policies, and protects myco_users.password from API exposure.

https://claude.ai/code/session_01WCB9bS5gkYANW6E9SvVymn

## Summary by Sourcery

Enable and enforce row-level security on previously unprotected public tables and secure exposure of user data.

New Features:
- Introduce a reusable migration that enables and forces row-level security on 16 public tables.
- Add a safe myco_users_safe view that exposes myco_users data without the password column.

Enhancements:
- Grant full access policies for the service_role and read-only policies for authenticated users across the affected tables.
- Harden access to the myco_users.password column by revoking direct selection from public-facing roles.

Documentation:
- Document the RLS migration, affected tables, and verification steps in a new RLS security fixes guide.