### PR TITLE
security: CVE-2026-31431 (Copy Fail) mitigation bundle

### DIFF
--- a/.github/workflows/cve-2026-31431-runner-precheck.yml
+++ b/.github/workflows/cve-2026-31431-runner-precheck.yml
@@ -1,0 +1,21 @@
+name: cve-2026-31431-runner-precheck
+on:
+  workflow_call: {}
+  workflow_dispatch: {}
+jobs:
+  kernel-precheck:
+    runs-on: self-hosted
+    steps:
+      - name: Refuse to run on unpatched runners
+        shell: bash
+        run: |
+          set -euo pipefail
+          if lsmod | awk '{print $1}' | grep -qx algif_aead; then
+            echo "::error::algif_aead loaded on runner -- CVE-2026-31431 exposure."
+            exit 1
+          fi
+          if ! grep -rqE '^install\\s+algif_aead\\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+            echo "::error::CVE-2026-31431 mitigation not applied to runner."
+            exit 1
+          fi
+          echo runner-precheck ok

--- a/docs/security/cve-2026-31431-report.md
+++ b/docs/security/cve-2026-31431-report.md
@@ -1,0 +1,80 @@
+# CVE-2026-31431 ("Copy Fail") -- mitigation & adjacent-issue report
+
+**Repo scope:** `mycosoftlabs/mycosoft-mas`
+**Status:** mitigation artifacts staged; host rollout via Ansible pending operator action.
+
+## 1. Vulnerability
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-31431 |
+| Nickname | Copy Fail |
+| Class | Linux kernel LPE -> container escape |
+| Root cause | 2017 in-place optimisation in `algif_aead` |
+| Primitive | 4-byte page-cache write via AF_ALG + splice() |
+| Affected | All mainstream Linux distros, kernels 4.14+ pre-fix |
+| Disclosed | 2026-04-29 (Theori) |
+| Upstream fix | mainline `a664bf3d603d` -- VERIFY on kernel.org |
+
+Page-cache write does not touch disk, so any setuid binary becomes a root
+trampoline. Page cache is host-wide -- containers don't isolate it. For an
+agent-orchestration codebase like `mycosoft-mas`, the relevant blast radius
+is: any agent / sandboxed task on a shared node can become host root.
+
+## 2. What this PR adds
+
+See `scripts/security/`, `ops/ansible/`, `ops/k8s/`,
+`.github/workflows/cve-2026-31431-runner-precheck.yml`,
+`scripts/ci/runner-precheck.sh`.
+
+## 3. Rollout checklist
+
+- [ ] Verify upstream commit `a664bf3d603d` against your distro tracker.
+- [ ] Run the Ansible playbook against MAS controller hosts, agent nodes, and any sandbox executors.
+- [ ] Reboot each host after the playbook.
+- [ ] Distribute the seccomp profile to every k8s node under `/var/lib/kubelet/seccomp/`.
+- [ ] Apply Kyverno policy; load Falco rules into the DaemonSet.
+- [ ] Install `runner-precheck.sh` as the GH Actions job-started hook on every self-hosted runner.
+- [ ] Wire `cve-2026-31431-detect.sh` into MAS health checks; alert on non-zero exit.
+
+## 4. Adjacent-issue audit (this repo)
+
+| Pattern | Hits | Notes |
+|---|---|---|
+| `AF_ALG`, `algif`, `algif_aead` | 0 | No application code touches the vulnerable interface. |
+| `splice`, `vmsplice` in C/Py/Go/Rust | 0 | No userland splice callers. |
+| `privileged: true` in manifests | 0 | No privileged containers surfaced. |
+| `hostNetwork`/`hostPID`/`hostIPC` | 0 | No host-namespace pods. |
+| `SYS_MODULE`/`CAP_SYS_ADMIN`/`allowPrivilegeEscalation` | 0 | No capability-elevating manifests. |
+| `USER root` in Dockerfile | 0 | No explicit root-Dockerfile pattern. |
+
+No direct application-code exposure detected.
+
+## 5. Related CVEs to track
+
+- CVE-2022-0847 (Dirty Pipe)
+- CVE-2022-2602 (io_uring + unix GC)
+- CVE-2023-32233 (nf_tables UAF)
+- CVE-2024-1086 (nf_tables double-free)
+- Historical `algif_*` family bugs
+
+## 6. Hardening recommendations
+
+1. Keep `algif_*` blocked permanently -- MAS workloads do not need AF_ALG.
+2. Default-deny seccomp at cluster level; this PR's profile is the floor.
+3. CI gate `cve-2026-31431-detect.sh` before scheduling any agent run.
+4. Feed Falco rule hits into the SOC dashboard for paging.
+5. For agent sandboxes spawning untrusted code, treat the seccomp profile as required, not optional.
+
+## 7. Verification
+
+```bash
+sudo bash scripts/security/cve-2026-31431-mitigate.sh
+bash scripts/security/cve-2026-31431-detect.sh && echo MITIGATED
+kubectl apply -f ops/k8s/cve-2026-31431-kyverno-policy.yaml
+```
+
+## 8. Caveats
+
+- Commit `a664bf3d603d` taken from disclosure post; NOT independently verified here.
+- Kyverno-specific; translate for OPA / Gatekeeper / PSA if needed.

--- a/ops/ansible/cve-2026-31431.yml
+++ b/ops/ansible/cve-2026-31431.yml
@@ -1,0 +1,47 @@
+---
+- name: Mitigate CVE-2026-31431 (Copy Fail)
+  hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    modprobe_conf: /etc/modprobe.d/disable-algif.conf
+    algif_modules: [algif_aead, algif_hash, algif_skcipher, algif_rng]
+  tasks:
+    - name: Persist modprobe block for algif_*
+      ansible.builtin.copy:
+        dest: "{{ modprobe_conf }}"
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          # Managed by ansible (CVE-2026-31431 mitigation).
+          {% for m in algif_modules %}
+          install {{ m }} /bin/false
+          {% endfor %}
+      notify: rebuild initramfs
+    - name: Unload algif_* modules if loaded
+      community.general.modprobe:
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ algif_modules }}"
+      failed_when: false
+    - name: Capture lsmod
+      ansible.builtin.shell: lsmod | awk '{print $1}'
+      register: lsmod_out
+      changed_when: false
+    - name: Fail if an algif module is still loaded
+      ansible.builtin.fail:
+        msg: "algif module still loaded: {{ item }}"
+      when: item in lsmod_out.stdout_lines
+      loop: "{{ algif_modules }}"
+    - name: Record mitigation marker
+      ansible.builtin.copy:
+        dest: /var/lib/cve-2026-31431.applied
+        content: "{{ ansible_date_time.iso8601 }}\n"
+        mode: "0644"
+  handlers:
+    - name: rebuild initramfs
+      ansible.builtin.shell: |
+        if command -v update-initramfs >/dev/null 2>&1; then update-initramfs -u
+        elif command -v dracut >/dev/null 2>&1; then dracut --force
+        fi

--- a/ops/k8s/cve-2026-31431-falco-rules.yaml
+++ b/ops/k8s/cve-2026-31431-falco-rules.yaml
@@ -1,0 +1,21 @@
+---
+- macro: af_alg_socket
+  condition: (evt.type=socket and evt.arg.domain=AF_ALG)
+
+- rule: AF_ALG socket created
+  desc: CVE-2026-31431 primitive; almost nothing legitimate needs AF_ALG.
+  condition: af_alg_socket and not proc.name in (cryptsetup, systemd-cryptsetup)
+  output: >
+    AF_ALG socket created (user=%user.name pid=%proc.pid proc=%proc.name
+    cmdline=%proc.cmdline container=%container.id image=%container.image.repository)
+  priority: CRITICAL
+  tags: [cve-2026-31431, kernel, exploit]
+
+- rule: splice from AF_ALG fd
+  desc: splice() from an AF_ALG fd -- Copy Fail page-cache write primitive.
+  condition: evt.type=splice and (fd.type=alg or fd.l4proto=alg)
+  output: >
+    splice() from AF_ALG fd (user=%user.name pid=%proc.pid proc=%proc.name
+    cmdline=%proc.cmdline)
+  priority: CRITICAL
+  tags: [cve-2026-31431, kernel, exploit]

--- a/ops/k8s/cve-2026-31431-kyverno-policy.yaml
+++ b/ops/k8s/cve-2026-31431-kyverno-policy.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cve-2026-31431-require-af-alg-seccomp
+  annotations:
+    policies.kyverno.io/title: Block AF_ALG (CVE-2026-31431)
+    policies.kyverno.io/category: Kernel Hardening
+    policies.kyverno.io/severity: critical
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-block-af-alg-seccomp
+      match:
+        any: [{resources: {kinds: ["Pod"]}}]
+      exclude:
+        any: [{resources: {namespaces: ["kube-system"]}}]
+      validate:
+        message: Pods must reference seccomp profile block-af-alg.json (CVE-2026-31431).
+        pattern:
+          spec:
+            securityContext:
+              seccompProfile:
+                type: Localhost
+                localhostProfile: block-af-alg.json
+    - name: forbid-host-namespaces
+      match:
+        any: [{resources: {kinds: ["Pod"]}}]
+      validate:
+        message: hostNetwork/hostPID/hostIPC widen CVE-2026-31431 blast radius.
+        pattern:
+          spec:
+            =(hostNetwork): "false"
+            =(hostPID): "false"
+            =(hostIPC): "false"

--- a/ops/k8s/seccomp/block-af-alg.json
+++ b/ops/k8s/seccomp/block-af-alg.json
@@ -1,0 +1,12 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "syscalls": [
+    {
+      "names": ["socket", "socketpair"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 1,
+      "args": [{ "index": 0, "value": 38, "op": "SCMP_CMP_EQ" }],
+      "comment": "Deny AF_ALG (38) -- CVE-2026-31431"
+    }
+  ]
+}

--- a/scripts/ci/runner-precheck.sh
+++ b/scripts/ci/runner-precheck.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Install as ACTIONS_RUNNER_HOOK_JOB_STARTED on self-hosted runners.
+set -euo pipefail
+if lsmod | awk '{print $1}' | grep -qx algif_aead; then
+    echo "[abort] algif_aead loaded -- runner unpatched (CVE-2026-31431)"; exit 1
+fi
+if ! grep -rqE '^install\s+algif_aead\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+    echo "[abort] CVE-2026-31431 mitigation not present"; exit 1
+fi
+exit 0

--- a/scripts/security/cve-2026-31431-detect.sh
+++ b/scripts/security/cve-2026-31431-detect.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Detect exposure to CVE-2026-31431. 0=mitigated, 1=exposed, 2=indeterminate.
+set -uo pipefail
+status=0
+note() { printf '%s\n' "$*" >&2; }
+
+note "kernel: $(uname -r)"
+
+if grep -rqE '^install\s+algif_aead\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+    note "[ok] modprobe block present"
+else
+    note "[!] no modprobe block for algif_aead"; status=1
+fi
+
+if lsmod 2>/dev/null | awk '{print $1}' | grep -qx algif_aead; then
+    note "[!] algif_aead is loaded"; status=1
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import socket, sys
+try:
+    s = socket.socket(38, socket.SOCK_SEQPACKET, 0)
+    s.close()
+    print("[!] AF_ALG socket creation succeeded from unprivileged context")
+    sys.exit(3)
+except OSError as e:
+    print(f"[ok] AF_ALG blocked: {e}")
+    sys.exit(0)
+PY
+    [[ $? -eq 3 ]] && status=1
+fi
+exit ${status}

--- a/scripts/security/cve-2026-31431-mitigate.sh
+++ b/scripts/security/cve-2026-31431-mitigate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# CVE-2026-31431 ("Copy Fail") host-level mitigation.
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "must run as root" >&2; exit 1
+fi
+
+CONF=/etc/modprobe.d/disable-algif.conf
+echo "[*] writing ${CONF}"
+cat >"${CONF}" <<'EOF'
+# Managed file. CVE-2026-31431 mitigation. Do not remove without a patched kernel.
+install algif_aead    /bin/false
+install algif_hash    /bin/false
+install algif_skcipher /bin/false
+install algif_rng     /bin/false
+EOF
+chmod 0644 "${CONF}"
+
+for mod in algif_aead algif_hash algif_skcipher algif_rng; do
+    if lsmod | awk '{print $1}' | grep -qx "${mod}"; then
+        rmmod "${mod}" 2>/dev/null || echo "[!] could not unload ${mod} (in use?)"
+    fi
+done
+
+if command -v update-initramfs >/dev/null 2>&1; then update-initramfs -u || true
+elif command -v dracut >/dev/null 2>&1; then dracut --force || true
+fi
+
+echo "[+] mitigation applied. reboot recommended."


### PR DESCRIPTION
## Summary

Stages mitigation artifacts for **CVE-2026-31431 ("Copy Fail")** — Linux kernel LPE in `algif_aead`, 4-byte page-cache write -> root via any setuid binary, container-escapes (page cache is host-wide). Disclosed 2026-04-29.

For an agent-orchestration codebase, the blast radius is: **any agent or sandbox task on a shared node can become host root**. The Kyverno seccomp policy + Falco rules in this PR are the relevant tenant-isolation layer.

## What's included

Same bundle as the other org repos: host mitigation/detection scripts, Ansible playbook, Kyverno policy + seccomp profile, Falco rules, runner pre-check, full findings report in `docs/security/cve-2026-31431-report.md`.

## Adjacent-issue audit (this repo)

GitHub code search returned **0 hits** for `AF_ALG`, `algif`, `splice`/`vmsplice`, `privileged: true`, `hostNetwork/PID/IPC`, `SYS_MODULE`/`CAP_SYS_ADMIN`, `USER root`. No direct application-code exposure.

## Caveats

- Upstream commit `a664bf3d603d` from the disclosure post is **not independently verified** here.
- Kyverno-specific; translate for your admission controller if different.

## Test plan

- [ ] `bash scripts/security/cve-2026-31431-mitigate.sh` on a staging MAS node; reboot; detect script exits 0.
- [ ] `ansible-playbook --check ops/ansible/cve-2026-31431.yml`.
- [ ] Kyverno policy dry-run apply on staging cluster.
- [ ] Falco rule verification with a deliberate `socket(AF_ALG)`.
- [ ] Runner pre-check verification on one self-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXuz2NPKgVn226KaV58czU)_

## Summary by Sourcery

Add a mitigation bundle for CVE-2026-31431 (Linux kernel AF_ALG page-cache write LPE) across hosts, Kubernetes, and CI runners.

New Features:
- Introduce host-level mitigation and detection scripts for CVE-2026-31431 to block algif_* kernel modules and verify protection.
- Add an Ansible playbook to roll out the CVE-2026-31431 mitigation configuration and validate module state on managed hosts.
- Define a Kyverno ClusterPolicy and seccomp profile requirement to block AF_ALG usage and disallow host namespaces for pods.
- Add Falco rules to detect AF_ALG socket creation and splice-based exploitation attempts related to CVE-2026-31431.
- Introduce CI runner pre-checks in GitHub Actions and runner hooks to refuse jobs on unmitigated self-hosted runners.

CI:
- Add a reusable GitHub Actions workflow that enforces CVE-2026-31431 mitigation on self-hosted runners before executing jobs.

Documentation:
- Document the CVE-2026-31431 vulnerability, mitigation steps, adjacent-issue audit, and verification guidance for this repository.