### PR TITLE
feat(compliance): evidence register metadata API (Part E)

### DIFF
--- a/docs/EVIDENCE_REGISTER_API_JUL22_2026.md
+++ b/docs/EVIDENCE_REGISTER_API_JUL22_2026.md
@@ -1,0 +1,76 @@
+# Evidence Register API (MAS) — Jul 22, 2026
+
+**Status:** Implemented  
+**Endpoint:** `GET /api/security/evidence-register`  
+**Host:** MAS orchestrator `http://192.168.0.188:8001`  
+**Auth:** `X-API-Key: $MYCA_POSTURE_API_KEY` (same as Patch v2 security/posture routes)
+
+## Purpose
+
+Expose **metadata only** from `CODE/docs/cmmc_evidence/REGISTER.md` (or `REGISTER.json` sidecar) for the Security tab evidence table. Never returns PDF bodies, PreVeil file contents, or other artifact bytes.
+
+## Response shape
+
+```json
+{
+  "source": "REGISTER.md",
+  "register_path": "/path/to/REGISTER.md",
+  "count": 25,
+  "entries": [
+    {
+      "id": "EV-PS-001",
+      "controls": ["PS.L2-3.9.2", "3.9.2"],
+      "artifact_path": "docs/cmmc_evidence/ps/PS_L2-3.9.2_RJ_Access_Agreement_SIGNED_JUL2026.pdf",
+      "artifact_name": "PS_L2-3.9.2_RJ_Access_Agreement_SIGNED_JUL2026.pdf",
+      "sha256": "b2a49cec9d291eade0737baa5ba96d6fc9777cb3406b99174884290eab0dc435",
+      "signer": "Raljoseph Ricasata (RJ Ricasata, CFO)",
+      "storage_tier": "internal_repo",
+      "classification": "UNCLASSIFIED",
+      "docusign_envelope": "AC00FC6C-EDA2-84FE-82C7-391A5236C1D9"
+    }
+  ]
+}
+```
+
+### `storage_tier` enum
+
+| Value | Meaning |
+|-------|---------|
+| `preveil` | PreVeil enclave / `/CUI/` path |
+| `internal_repo` | Internal CODE tree (`docs/cmmc_evidence/…`) |
+| `google_drive` | Google Drive file id / path |
+| `public_repo` | Public git repo (never CUI) |
+
+## Configuration (MAS VM)
+
+Set on MAS `.env` (merge-only — do not truncate):
+
+```env
+CMMC_EVIDENCE_REGISTER_PATH=/opt/mycosoft/CODE/docs/cmmc_evidence/REGISTER.md
+# optional override for JSON sidecar (preferred when present):
+# CMMC_EVIDENCE_REGISTER_JSON=/opt/mycosoft/CODE/docs/cmmc_evidence/REGISTER.json
+```
+
+If `REGISTER.json` exists beside the markdown register, the API prefers the JSON sidecar.
+
+## Frontend wiring (Claude)
+
+1. Website Security tab: proxy `GET /api/security/evidence-register` via existing MAS proxy pattern with `X-API-Key` from server env.
+2. Render table columns: id, controls, artifact_name, sha256 (truncated), signer, storage_tier, classification, docusign_envelope.
+3. Do **not** fetch artifact paths as downloadable URLs from this endpoint — metadata pointers only.
+
+## Verification
+
+```bash
+# 401 without key
+curl -s -o /dev/null -w "%{http_code}" http://192.168.0.188:8001/api/security/evidence-register
+
+# 200 with key
+curl -s -H "X-API-Key: $MYCA_POSTURE_API_KEY" http://192.168.0.188:8001/api/security/evidence-register | jq '.count,.entries[0].id'
+```
+
+## Related
+
+- Patch v2 emitter: `mycosoft_mas/core/routers/security_evidence_api.py`
+- Register source: `CODE/docs/cmmc_evidence/REGISTER.md`
+- PS.L2-3.9.2 flip: `doc:access-agreement#EV-PS-001` via `scripts/_cmmc_ps_392_flip_jul22_2026.py`

--- a/mycosoft_mas/compliance/evidence_register.py
+++ b/mycosoft_mas/compliance/evidence_register.py
@@ -1,0 +1,248 @@
+"""
+CMMC evidence register reader — metadata only (no file bodies).
+
+Prefers REGISTER.json sidecar when present; otherwise parses REGISTER.md tables.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+StorageTier = Literal["preveil", "internal_repo", "google_drive", "public_repo"]
+
+_CONTROL_RE = re.compile(
+    r"(?:[A-Z]{2}\.)?L2-\d+(?:\.\d+)+|\b\d+\.\d+(?:\.\d+)+\b"
+)
+_SHA256_RE = re.compile(r"\b([a-fA-F0-9]{64})\b")
+_ENVELOPE_UUID_RE = re.compile(
+    r"\b([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})\b",
+    re.IGNORECASE,
+)
+_BACKTICK_PATH_RE = re.compile(r"`([^`]+)`")
+
+
+def resolve_register_markdown_path() -> Optional[Path]:
+    explicit = os.getenv("CMMC_EVIDENCE_REGISTER_PATH", "").strip()
+    if explicit:
+        return Path(explicit)
+
+    candidates: list[Path] = []
+    code_root = os.getenv("CODE_ROOT", "").strip()
+    if code_root:
+        candidates.append(Path(code_root) / "docs" / "cmmc_evidence" / "REGISTER.md")
+
+    mas_root = Path(__file__).resolve().parents[2]
+    candidates.extend(
+        [
+            mas_root.parent.parent / "docs" / "cmmc_evidence" / "REGISTER.md",
+            Path("/opt/mycosoft/CODE/docs/cmmc_evidence/REGISTER.md"),
+            Path("/home/mycosoft/CODE/docs/cmmc_evidence/REGISTER.md"),
+            Path("/home/mycosoft/mycosoft/CODE/docs/cmmc_evidence/REGISTER.md"),
+        ]
+    )
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def resolve_register_json_path(markdown_path: Optional[Path]) -> Optional[Path]:
+    explicit_json = os.getenv("CMMC_EVIDENCE_REGISTER_JSON", "").strip()
+    if explicit_json:
+        path = Path(explicit_json)
+        return path if path.is_file() else None
+    if markdown_path is not None:
+        sidecar = markdown_path.parent / "REGISTER.json"
+        if sidecar.is_file():
+            return sidecar
+    return None
+
+
+def infer_storage_tier(storage_text: str, artifact_text: str) -> StorageTier:
+    combined = f"{storage_text} {artifact_text}".lower()
+    if "preveil" in combined:
+        return "preveil"
+    if "google" in combined and "drive" in combined:
+        return "google_drive"
+    if "public" in combined and "repo" in combined:
+        return "public_repo"
+    return "internal_repo"
+
+
+def extract_controls(text: str) -> list[str]:
+    seen: set[str] = set()
+    controls: list[str] = []
+    for match in _CONTROL_RE.findall(text or ""):
+        token = match.strip()
+        if token and token not in seen:
+            seen.add(token)
+            controls.append(token)
+    return controls
+
+
+def extract_sha256(text: str) -> Optional[str]:
+    match = _SHA256_RE.search(text or "")
+    return match.group(1).lower() if match else None
+
+
+def extract_docusign_envelope(*texts: str) -> Optional[str]:
+    for text in texts:
+        if not text:
+            continue
+        match = _ENVELOPE_UUID_RE.search(text)
+        if match:
+            return match.group(1).upper()
+    return None
+
+
+def extract_artifact_path(text: str) -> Optional[str]:
+    if not text:
+        return None
+    for match in _BACKTICK_PATH_RE.finditer(text):
+        candidate = match.group(1).strip()
+        if "/" in candidate or candidate.endswith((".pdf", ".md", ".png", ".jpg")):
+            return candidate
+    stripped = text.strip().strip("`")
+    if stripped and not stripped.startswith("http"):
+        first = stripped.split("+")[0].split(",")[0].strip()
+        if first:
+            return first
+    return None
+
+
+def artifact_name_from_path(path: Optional[str]) -> Optional[str]:
+    if not path:
+        return None
+    return Path(path.replace("\\", "/")).name
+
+
+def _parse_table_rows(content: str) -> list[tuple[list[str], dict[str, str]]]:
+    """Return (header_cells, {header: value}) for each data row in markdown tables."""
+    rows: list[tuple[list[str], dict[str, str]]] = []
+    lines = content.splitlines()
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line.startswith("|") or "id" not in line.lower():
+            idx += 1
+            continue
+
+        header = [cell.strip().lower() for cell in line.strip("|").split("|")]
+        idx += 1
+        if idx < len(lines) and set(lines[idx].replace("|", "").replace("-", "").strip()) <= {""}:
+            idx += 1
+
+        while idx < len(lines):
+            row_line = lines[idx].strip()
+            if not row_line.startswith("|"):
+                break
+            cells = [cell.strip() for cell in row_line.strip("|").split("|")]
+            if len(cells) < len(header):
+                cells.extend([""] * (len(header) - len(cells)))
+            row_map = {header[i]: cells[i] for i in range(len(header))}
+            if row_map.get("id"):
+                rows.append((header, row_map))
+            idx += 1
+    return rows
+
+
+def _entry_from_row(header: list[str], row: dict[str, str]) -> Optional[dict[str, Any]]:
+    entry_id = row.get("id", "").strip()
+    if not entry_id:
+        return None
+
+    controls_col = row.get("control(s)", "") or row.get("family / controls (concepts)", "")
+    artifact_col = row.get("artifact (internal path)", "") or row.get("artifact", "")
+    artifact_path = extract_artifact_path(artifact_col)
+    storage_col = row.get("storage", "")
+    classification_col = row.get("classification", "UNCLASSIFIED")
+    signer_col = row.get("signer", "")
+    sha_col = row.get("sha256", "")
+    envelope_col = row.get("envelope", "")
+
+    envelope = extract_docusign_envelope(envelope_col, row.get("signed date", ""), row.get("verdict", ""), artifact_col)
+    if not envelope:
+        envelope = extract_docusign_envelope(signer_col)
+
+    return {
+        "id": entry_id,
+        "controls": extract_controls(controls_col),
+        "artifact_path": artifact_path,
+        "artifact_name": artifact_name_from_path(artifact_path),
+        "sha256": extract_sha256(sha_col),
+        "signer": signer_col or None,
+        "storage_tier": infer_storage_tier(storage_col, artifact_col),
+        "classification": classification_col.strip() or "UNCLASSIFIED",
+        "docusign_envelope": envelope,
+    }
+
+
+def parse_register_markdown(content: str) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for header, row in _parse_table_rows(content):
+        entry = _entry_from_row(header, row)
+        if entry and entry["id"] not in seen_ids:
+            seen_ids.add(entry["id"])
+            entries.append(entry)
+    return entries
+
+
+def load_register_json(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("entries"), list):
+        raw_entries = payload["entries"]
+    elif isinstance(payload, list):
+        raw_entries = payload
+    else:
+        raise ValueError("REGISTER.json must be a list or {entries: [...]}")
+    return [_normalize_json_entry(item) for item in raw_entries]
+
+
+def _normalize_json_entry(item: dict[str, Any]) -> dict[str, Any]:
+    artifact_path = item.get("artifact_path") or item.get("artifact")
+    storage_tier = item.get("storage_tier", "internal_repo")
+    if storage_tier not in {"preveil", "internal_repo", "google_drive", "public_repo"}:
+        storage_tier = infer_storage_tier(str(item.get("storage", "")), str(artifact_path or ""))
+    return {
+        "id": item["id"],
+        "controls": list(item.get("controls") or []),
+        "artifact_path": artifact_path,
+        "artifact_name": item.get("artifact_name") or artifact_name_from_path(str(artifact_path or "")),
+        "sha256": (item.get("sha256") or "").lower() or None,
+        "signer": item.get("signer"),
+        "storage_tier": storage_tier,
+        "classification": item.get("classification") or "UNCLASSIFIED",
+        "docusign_envelope": item.get("docusign_envelope"),
+    }
+
+
+def load_evidence_register() -> dict[str, Any]:
+    markdown_path = resolve_register_markdown_path()
+    json_path = resolve_register_json_path(markdown_path)
+
+    if json_path is not None:
+        entries = load_register_json(json_path)
+        return {
+            "source": "REGISTER.json",
+            "register_path": str(json_path),
+            "count": len(entries),
+            "entries": entries,
+        }
+
+    if markdown_path is None:
+        raise FileNotFoundError("CMMC evidence register not found (set CMMC_EVIDENCE_REGISTER_PATH)")
+
+    content = markdown_path.read_text(encoding="utf-8")
+    entries = parse_register_markdown(content)
+    return {
+        "source": "REGISTER.md",
+        "register_path": str(markdown_path),
+        "count": len(entries),
+        "entries": entries,
+    }

--- a/mycosoft_mas/compliance/evidence_register.py
+++ b/mycosoft_mas/compliance/evidence_register.py
@@ -22,6 +22,7 @@ _ENVELOPE_UUID_RE = re.compile(
     r"\b([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})\b",
     re.IGNORECASE,
 )
+_ENVELOPE_HEX_RE = re.compile(r"\b([A-F0-9]{32})\b", re.IGNORECASE)
 _BACKTICK_PATH_RE = re.compile(r"`([^`]+)`")
 
 
@@ -96,6 +97,9 @@ def extract_docusign_envelope(*texts: str) -> Optional[str]:
             continue
         match = _ENVELOPE_UUID_RE.search(text)
         if match:
+            return match.group(1).upper()
+        match = _ENVELOPE_HEX_RE.search(text)
+        if match and "envelope" in text.lower():
             return match.group(1).upper()
     return None
 
@@ -182,6 +186,25 @@ def _entry_from_row(header: list[str], row: dict[str, str]) -> Optional[dict[str
     }
 
 
+def enrich_envelopes_from_register(content: str, entries: list[dict[str, Any]]) -> None:
+    for entry in entries:
+        if entry.get("docusign_envelope"):
+            continue
+        marker = 0
+        envelope: Optional[str] = None
+        while True:
+            idx = content.find(entry["id"], marker)
+            if idx == -1:
+                break
+            snippet = content[idx : idx + 2500]
+            envelope = extract_docusign_envelope(snippet)
+            if envelope:
+                break
+            marker = idx + len(entry["id"])
+        if envelope:
+            entry["docusign_envelope"] = envelope
+
+
 def parse_register_markdown(content: str) -> list[dict[str, Any]]:
     entries: list[dict[str, Any]] = []
     seen_ids: set[str] = set()
@@ -190,6 +213,7 @@ def parse_register_markdown(content: str) -> list[dict[str, Any]]:
         if entry and entry["id"] not in seen_ids:
             seen_ids.add(entry["id"])
             entries.append(entry)
+    enrich_envelopes_from_register(content, entries)
     return entries
 
 

--- a/mycosoft_mas/core/routers/security_evidence_api.py
+++ b/mycosoft_mas/core/routers/security_evidence_api.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Header, HTTPException, status
 from pydantic import BaseModel, Field
 
 from mycosoft_mas.compliance.evidence_emitter import EVIDENCE_TYPES, emit_evidence
+from mycosoft_mas.compliance.evidence_register import load_evidence_register
 from mycosoft_mas.core.routers.compliance_api import _require_posture_api_key
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,21 @@ class IrTabletopRequest(BaseModel):
     findings_md: str = Field(min_length=1)
     recording_preveil_path: str
     control_ids: List[str] = Field(default_factory=lambda: ["IR.L2-3.6.3", "3.6.3"])
+
+
+@router.get("/evidence-register")
+async def get_evidence_register(
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+):
+    """Metadata-only CMMC evidence register for Security tab proxy (no file bodies)."""
+    _require_posture_api_key(x_api_key)
+    try:
+        return load_evidence_register()
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("get_evidence_register: %s", exc)
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @router.get("/ps/screening-events")

--- a/tests/test_security_evidence_register_api.py
+++ b/tests/test_security_evidence_register_api.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mycosoft_mas.compliance import evidence_register
+from mycosoft_mas.core.routers import security_evidence_api
+
+
+SAMPLE_REGISTER = """\
+| id | control(s) | verdict | artifact (internal path) | sha256 | bytes | signer | signed date | storage | classification |
+|---|---|---|---|---|---|---|---|---|---|
+| EV-PS-001 | PS.L2-3.9.2 (+ NIST twin 3.9.2) | filed | `docs/cmmc_evidence/ps/agreement.pdf` | `b2a49cec9d291eade0737baa5ba96d6fc9777cb3406b99174884290eab0dc435` | 319846 | RJ Ricasata | 2026-07-15 (DocuSign AC00FC6C-EDA2-84FE-82C7-391A5236C1D9) | internal CODE | UNCLASSIFIED |
+| EV-POL-CERT-SC | SC-bundle | PARTIAL | `docs/cmmc_evidence/policies/signed/CERT_SC.pdf` | `17084ceeba34d5ef2c3919eb8cc1de8413444fa53da71ef498f4fff8ba724c14` | 99082 | Morgan Rockcoons | 2026-07-16 | internal CODE | UNCLASSIFIED |
+"""
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(security_evidence_api.router)
+    return TestClient(app)
+
+
+def test_parse_register_markdown_extracts_metadata() -> None:
+    entries = evidence_register.parse_register_markdown(SAMPLE_REGISTER)
+    by_id = {entry["id"]: entry for entry in entries}
+
+    ps = by_id["EV-PS-001"]
+    assert ps["controls"] == ["PS.L2-3.9.2", "3.9.2"]
+    assert ps["artifact_path"] == "docs/cmmc_evidence/ps/agreement.pdf"
+    assert ps["artifact_name"] == "agreement.pdf"
+    assert ps["sha256"] == "b2a49cec9d291eade0737baa5ba96d6fc9777cb3406b99174884290eab0dc435"
+    assert ps["signer"] == "RJ Ricasata"
+    assert ps["storage_tier"] == "internal_repo"
+    assert ps["classification"] == "UNCLASSIFIED"
+    assert ps["docusign_envelope"] == "AC00FC6C-EDA2-84FE-82C7-391A5236C1D9"
+
+
+def test_evidence_register_requires_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("MYCA_POSTURE_API_KEY", "test-posture-key")
+
+    response = _client().get("/api/security/evidence-register")
+
+    assert response.status_code == 401
+
+
+def test_evidence_register_returns_metadata_shape(monkeypatch) -> None:
+    monkeypatch.setenv("MYCA_POSTURE_API_KEY", "test-posture-key")
+    monkeypatch.setattr(
+        security_evidence_api,
+        "load_evidence_register",
+        lambda: {
+            "source": "REGISTER.md",
+            "register_path": "/tmp/REGISTER.md",
+            "count": 1,
+            "entries": [
+                {
+                    "id": "EV-PS-001",
+                    "controls": ["PS.L2-3.9.2", "3.9.2"],
+                    "artifact_path": "docs/cmmc_evidence/ps/agreement.pdf",
+                    "artifact_name": "agreement.pdf",
+                    "sha256": "b2a49cec9d291eade0737baa5ba96d6fc9777cb3406b99174884290eab0dc435",
+                    "signer": "RJ Ricasata",
+                    "storage_tier": "internal_repo",
+                    "classification": "UNCLASSIFIED",
+                    "docusign_envelope": "AC00FC6C-EDA2-84FE-82C7-391A5236C1D9",
+                }
+            ],
+        },
+    )
+
+    response = _client().get(
+        "/api/security/evidence-register",
+        headers={"X-API-Key": "test-posture-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    entry = body["entries"][0]
+    assert set(entry.keys()) == {
+        "id",
+        "controls",
+        "artifact_path",
+        "artifact_name",
+        "sha256",
+        "signer",
+        "storage_tier",
+        "classification",
+        "docusign_envelope",
+    }
+    assert ".pdf" not in response.text or "artifact_path" in response.text
+    assert "BEGIN PDF" not in response.text


### PR DESCRIPTION
## Summary
- Adds GET /api/security/evidence-register (metadata only, X-API-Key auth)
- Parses CODE/docs/cmmc_evidence/REGISTER.md or REGISTER.json sidecar
- Tests for auth + response shape

## Test plan
- [x] pytest tests/test_security_evidence_register_api.py
- [ ] Verify 401 without key / 200 with key on 188:8001 after deploy

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add a secured API endpoint to expose metadata from the CMMC evidence register and supporting utilities to load and parse that register from markdown or JSON.

New Features:
- Expose GET /api/security/evidence-register endpoint that returns metadata-only evidence register data secured by X-API-Key.
- Introduce evidence register loader that resolves REGISTER.md/REGISTER.json locations, parses markdown tables or JSON entries, and normalizes metadata for API consumers.

Enhancements:
- Derive structured evidence metadata such as controls, artifact paths, classifications, storage tiers, and DocuSign envelope IDs from register content for consistent downstream use.

Documentation:
- Document the evidence register API contract, configuration, and frontend integration details in a new markdown spec file.

Tests:
- Add unit tests for parsing evidence register markdown metadata and for the evidence-register API’s authentication and response shape.