### PR TITLE
feat(soc): add honest backend contracts

### DIFF
--- a/.cursor/rules/morgan-sole-github-approver-jul22.mdc
+++ b/.cursor/rules/morgan-sole-github-approver-jul22.mdc
@@ -1,0 +1,11 @@
+# Morgan — Sole GitHub Code Approver
+
+**Effective date:** July 22, 2026
+
+Morgan is the sole GitHub code approver for Mycosoft repositories. Do not wait
+for, request, or require RJ approval before merging a pull request.
+
+When Morgan explicitly authorizes a merge, an administrator may merge the pull
+request only after every required GitHub check is successful. Never override a
+failed or in-progress required check. Use the repository administrator merge
+path when it is needed to complete Morgan's authorized merge.

--- a/config/security/authorized-users.json
+++ b/config/security/authorized-users.json
@@ -28,62 +28,6 @@
       "mfa_enabled": true
     },
     {
-      "id": "chris-002",
-      "name": "Chris",
-      "role": "admin",
-      "email": "chris@mycosoft.com",
-      "locations": [
-        {
-          "name": "Portland",
-          "city": "Portland",
-          "state": "OR",
-          "country": "US",
-          "timezone": "America/Los_Angeles",
-          "coordinates": { "lat": 45.5152, "lng": -122.6784 },
-          "radius_km": 30,
-          "primary": true
-        }
-      ],
-      "devices": [],
-      "access_level": "full",
-      "mobile_access": true,
-      "vpn_allowed": true,
-      "mfa_enabled": true
-    },
-    {
-      "id": "garrett-003",
-      "name": "Garrett",
-      "role": "admin",
-      "email": "garrett@mycosoft.com",
-      "locations": [
-        {
-          "name": "Pasadena",
-          "city": "Pasadena",
-          "state": "CA",
-          "country": "US",
-          "timezone": "America/Los_Angeles",
-          "coordinates": { "lat": 34.1478, "lng": -118.1445 },
-          "radius_km": 30,
-          "primary": true
-        },
-        {
-          "name": "Chula Vista (Visiting)",
-          "city": "Chula Vista",
-          "state": "CA",
-          "country": "US",
-          "timezone": "America/Los_Angeles",
-          "coordinates": { "lat": 32.6401, "lng": -117.0842 },
-          "radius_km": 15,
-          "primary": false
-        }
-      ],
-      "devices": [],
-      "access_level": "full",
-      "mobile_access": true,
-      "vpn_allowed": true,
-      "mfa_enabled": true
-    },
-    {
       "id": "rj-004",
       "name": "RJ",
       "role": "admin",
@@ -108,29 +52,6 @@
           "coordinates": { "lat": 32.7226, "lng": -117.1698 },
           "radius_km": 10,
           "primary": false
-        }
-      ],
-      "devices": [],
-      "access_level": "full",
-      "mobile_access": true,
-      "vpn_allowed": true,
-      "mfa_enabled": true
-    },
-    {
-      "id": "beto-005",
-      "name": "Beto",
-      "role": "admin",
-      "email": "beto@mycosoft.com",
-      "locations": [
-        {
-          "name": "Chula Vista",
-          "city": "Chula Vista",
-          "state": "CA",
-          "country": "US",
-          "timezone": "America/Los_Angeles",
-          "coordinates": { "lat": 32.6401, "lng": -117.0842 },
-          "radius_km": 15,
-          "primary": true
         }
       ],
       "devices": [],

--- a/mycosoft_mas/core/routers/guardian_api.py
+++ b/mycosoft_mas/core/routers/guardian_api.py
@@ -109,6 +109,26 @@ class EmergencyHaltRequest(BaseModel):
     reason: str
 
 
+class GuardianCommandRequest(BaseModel):
+    """A request-only SOC action; it never executes an operation directly."""
+
+    actor: str = Field(min_length=1)
+    reason: str = Field(min_length=1)
+    target: Dict[str, Any] = Field(default_factory=dict)
+    action: str = Field(min_length=1)
+    policy_class: str = Field(min_length=1)
+    correlation_id: str = Field(min_length=1)
+
+
+class GuardianCommandDecision(BaseModel):
+    decision: str
+    correlation_id: str
+    run_id: Optional[str] = None
+    reason: str
+    durable_recorded: bool
+    executable: bool
+
+
 # --- Endpoints ---
 
 
@@ -190,6 +210,36 @@ async def check_authority(request: AuthorityCheckRequest):
         "warnings": result.warnings,
         "pipeline_stages": result.pipeline_stages,
     }
+
+
+@router.post("/commands/request", response_model=GuardianCommandDecision)
+async def request_guardian_command(
+    request: GuardianCommandRequest,
+    _auth: dict = require_api_key_scoped("guardian:admin"),
+):
+    """
+    Accept the SOC command envelope without directly mutating the target.
+
+    A durable command ledger and approval workflow are not yet deployed.  The
+    endpoint therefore returns a non-executable approval-required decision
+    rather than presenting a browser request as a completed operation.
+    """
+    logger.warning(
+        "Guardian command request held: action=%s policy_class=%s correlation_id=%s",
+        request.action,
+        request.policy_class,
+        request.correlation_id,
+    )
+    return GuardianCommandDecision(
+        decision="requires_approval",
+        correlation_id=request.correlation_id,
+        reason=(
+            "The durable Guardian command ledger and approval workflow are "
+            "unavailable; no command was executed."
+        ),
+        durable_recorded=False,
+        executable=False,
+    )
 
 
 @router.get("/moral-precedence")

--- a/mycosoft_mas/core/routers/incidents_api.py
+++ b/mycosoft_mas/core/routers/incidents_api.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
@@ -32,12 +33,16 @@ class IncidentCreate(BaseModel):
     details: Dict[str, Any] = Field(default_factory=dict)
     tags: List[str] = Field(default_factory=list)
     timeline: List[Dict[str, Any]] = Field(default_factory=list)
+    reporter_id: Optional[str] = None
+    reporter_name: Optional[str] = None
 
 
 class IncidentPatch(BaseModel):
     status: Optional[str] = None
     assigned_to: Optional[str] = None
     timeline_append: Optional[Dict[str, Any]] = None
+    actor: Optional[str] = None
+    actor_id: Optional[str] = None
 
 
 @router.get("/health")
@@ -73,6 +78,21 @@ async def create_incident_api(body: IncidentCreate):
     try:
         from mycosoft_mas.soc import repository as soc_repo
 
+        details = dict(body.details)
+        if body.reporter_id or body.reporter_name:
+            details["reported_by"] = {
+                "id": body.reporter_id,
+                "name": body.reporter_name,
+            }
+        timeline = list(body.timeline)
+        if body.reporter_id or body.reporter_name:
+            timeline.append(
+                {
+                    "event": "reported",
+                    "actor": body.reporter_name,
+                    "actor_id": body.reporter_id,
+                }
+            )
         row = await soc_repo.create_incident(
             title=body.title,
             description=body.description,
@@ -82,9 +102,9 @@ async def create_incident_api(body: IncidentCreate):
             kind=body.kind,
             source_ip=body.source_ip,
             host=body.host,
-            details=body.details,
+            details=details,
             tags=body.tags,
-            timeline=body.timeline,
+            timeline=timeline,
         )
         return row
     except Exception as e:
@@ -123,11 +143,15 @@ async def patch_incident_api(incident_id: str, body: IncidentPatch):
     try:
         from mycosoft_mas.soc import repository as soc_repo
 
+        timeline_append = dict(body.timeline_append or {})
+        if body.actor or body.actor_id:
+            timeline_append["actor"] = body.actor
+            timeline_append["actor_id"] = body.actor_id
         row = await soc_repo.update_incident(
             incident_id,
             status=body.status,
             assigned_to=body.assigned_to,
-            timeline_append=body.timeline_append,
+            timeline_append=timeline_append or None,
         )
         if not row:
             raise HTTPException(status_code=404, detail="incident not found")
@@ -150,4 +174,20 @@ async def incident_chain_api(incident_id: str, limit: int = Query(200, ge=1, le=
         return {"incident_id": incident_id, "chain": chain}
     except Exception as e:
         logger.exception("incident_chain failed: %s", e)
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+
+@router.get("/chain/verify")
+async def verify_global_incident_chain_api():
+    """Return a factual global integrity result for persisted incident chains."""
+    if not _pg_ready():
+        raise HTTPException(status_code=503, detail="MINDEX_DATABASE_URL not configured")
+    try:
+        from mycosoft_mas.soc import repository as soc_repo
+
+        result = await soc_repo.verify_global_incident_chain()
+        result["verified_at"] = datetime.now(timezone.utc).isoformat()
+        return result
+    except Exception as e:
+        logger.exception("verify_global_incident_chain failed: %s", e)
         raise HTTPException(status_code=503, detail=str(e)) from e

--- a/mycosoft_mas/core/routers/redteam_api.py
+++ b/mycosoft_mas/core/routers/redteam_api.py
@@ -125,12 +125,46 @@ class SimulationResult(BaseModel):
     soc_incident_id: Optional[str] = None
 
 
+class ScenarioRunRequest(BaseModel):
+    scenario_id: str = Field(min_length=1)
+    reason: str = Field(min_length=1)
+
+
+class ScenarioRegistryEntry(BaseModel):
+    id: str
+    name: str
+    risk_class: str
+    allowed_scope: str
+    isolation_target: str
+    data_classification: str
+    cadence: Optional[str] = None
+    approval_class: str
+    kill_switch: str
+    required_evidence: List[str]
+
+
 # ═══════════════════════════════════════════════════════════════
 # STORAGE: redteam_store (Supabase when configured, else in-memory)
 # ═══════════════════════════════════════════════════════════════
 
 # Authorization tokens (production would validate against SSO/RBAC)
 valid_auth_tokens: set = set()
+
+
+def _legacy_simulations_enabled() -> bool:
+    """Legacy synthetic simulation endpoints are disabled unless explicitly isolated."""
+    return os.getenv("REDTEAM_LEGACY_SIMULATIONS_ENABLED", "0") == "1"
+
+
+def _require_isolated_legacy_simulations() -> None:
+    if not _legacy_simulations_enabled():
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                "Legacy synthetic red-team simulations are disabled. Use the "
+                "approved scenario registry and Guardian request contract."
+            ),
+        )
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -622,6 +656,41 @@ async def list_soc_redteam_findings(
         raise HTTPException(status_code=503, detail=str(e)) from e
 
 
+@router.get("/scenarios", response_model=List[ScenarioRegistryEntry])
+async def list_approved_scenarios():
+    """
+    List durable, approved scenarios only.
+
+    No authoritative scenario registry is deployed yet, so this contract is
+    intentionally unavailable rather than returning browser-era sample data.
+    """
+    raise HTTPException(
+        status_code=503,
+        detail=(
+            "Approved red-team scenario registry is not configured; no "
+            "scenario data is available."
+        ),
+    )
+
+
+@router.post("/runs")
+async def request_scenario_run(request: ScenarioRunRequest):
+    """
+    Request an approved scenario without accepting arbitrary scope or targets.
+
+    No durable scenario/run ledger is available, so no run is created and no
+    simulator is invoked.
+    """
+    logger.warning("Red-team scenario request held: scenario_id=%s", request.scenario_id)
+    raise HTTPException(
+        status_code=503,
+        detail=(
+            "Approved scenario-run ledger is not configured; no run was "
+            "created or executed."
+        ),
+    )
+
+
 @router.post("/authorize")
 async def request_authorization(description: str = "Red team simulation"):
     """
@@ -632,6 +701,7 @@ async def request_authorization(description: str = "Red team simulation"):
     - Approval workflow for sensitive tests
     - SSO for identity verification
     """
+    _require_isolated_legacy_simulations()
     token = generate_auth_token()
     logger.info(f"[RedTeam] Authorization token generated for: {description}")
 
@@ -655,6 +725,7 @@ async def start_simulation(
     Requires valid authorization code for execution.
     All simulations are logged to SOC.
     """
+    _require_isolated_legacy_simulations()
     # Validate authorization
     if not validate_authorization(request.authorization_code):
         raise HTTPException(
@@ -716,6 +787,7 @@ async def run_credential_test_endpoint(
     background_tasks: BackgroundTasks,
 ):
     """Run credential testing simulation."""
+    _require_isolated_legacy_simulations()
     if not validate_authorization(authorization_code):
         raise HTTPException(status_code=403, detail="Invalid authorization")
     approved_by = await _require_guardian_approval_if_needed(
@@ -750,6 +822,7 @@ async def run_phishing_sim_endpoint(
     background_tasks: BackgroundTasks,
 ):
     """Run phishing awareness simulation."""
+    _require_isolated_legacy_simulations()
     if not validate_authorization(authorization_code):
         raise HTTPException(status_code=403, detail="Invalid authorization")
     approved_by = await _require_guardian_approval_if_needed("phishing_sim", request.target_group)
@@ -786,6 +859,7 @@ async def run_pivot_test_endpoint(
     background_tasks: BackgroundTasks,
 ):
     """Run network pivot/segmentation test."""
+    _require_isolated_legacy_simulations()
     if not validate_authorization(authorization_code):
         raise HTTPException(status_code=403, detail="Invalid authorization")
     approved_by = await _require_guardian_approval_if_needed(
@@ -820,6 +894,7 @@ async def run_exfil_test_endpoint(
     background_tasks: BackgroundTasks,
 ):
     """Run data exfiltration detection test."""
+    _require_isolated_legacy_simulations()
     if not validate_authorization(authorization_code):
         raise HTTPException(status_code=403, detail="Invalid authorization")
     approved_by = await _require_guardian_approval_if_needed(

--- a/mycosoft_mas/soc/repository.py
+++ b/mycosoft_mas/soc/repository.py
@@ -357,6 +357,92 @@ async def list_chain_for_incident(incident_id: str, limit: int = 100) -> List[Di
     return out
 
 
+def _chain_hash(
+    previous_hash: str, sequence_number: int, event_type: str, payload: Dict[str, Any]
+) -> str:
+    body = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(
+        f"{previous_hash}|{sequence_number}|{event_type}|{body}".encode()
+    ).hexdigest()
+
+
+def _merkle_root(hashes: List[str]) -> str | None:
+    if not hashes:
+        return None
+    level = hashes
+    while len(level) > 1:
+        if len(level) % 2:
+            level = [*level, level[-1]]
+        level = [
+            hashlib.sha256(f"{left}{right}".encode()).hexdigest()
+            for left, right in zip(level[::2], level[1::2])
+        ]
+    return level[0]
+
+
+async def verify_global_incident_chain() -> Dict[str, Any]:
+    """Verify every persisted incident hash chain without inventing empty integrity."""
+    pool = await _pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT incident_id, sequence_number, prev_hash, event_hash, event_type, payload
+            FROM soc_ops.incident_chain
+            ORDER BY incident_id ASC, sequence_number ASC
+            """
+        )
+
+    previous_by_incident: Dict[str, str] = {}
+    next_sequence_by_incident: Dict[str, int] = {}
+    terminal_hashes: Dict[str, str] = {}
+    invalid_entries: List[Dict[str, Any]] = []
+
+    for row in rows:
+        incident_id = str(row["incident_id"])
+        payload = (
+            row["payload"]
+            if isinstance(row["payload"], dict)
+            else json.loads(row["payload"] or "{}")
+        )
+        expected_previous = previous_by_incident.get(incident_id, "0" * 64)
+        expected_sequence = next_sequence_by_incident.get(incident_id, 1)
+        expected_hash = _chain_hash(
+            expected_previous, row["sequence_number"], row["event_type"], payload
+        )
+        if (
+            row["sequence_number"] != expected_sequence
+            or row["prev_hash"] != expected_previous
+            or row["event_hash"] != expected_hash
+        ):
+            invalid_entries.append(
+                {
+                    "incident_id": incident_id,
+                    "sequence_number": row["sequence_number"],
+                }
+            )
+        previous_by_incident[incident_id] = row["event_hash"]
+        next_sequence_by_incident[incident_id] = row["sequence_number"] + 1
+        terminal_hashes[incident_id] = row["event_hash"]
+
+    entries = len(rows)
+    return {
+        "verified": entries > 0 and not invalid_entries,
+        "merkle_root": _merkle_root(
+            [terminal_hashes[incident_id] for incident_id in sorted(terminal_hashes)]
+        ),
+        "entries": entries,
+        "incidents": len(terminal_hashes),
+        "reason": (
+            "no incident-chain entries are available"
+            if entries == 0
+            else "hash-chain validation failed"
+            if invalid_entries
+            else None
+        ),
+        "invalid_entries": invalid_entries,
+    }
+
+
 async def upsert_device_inventory(
     *,
     mac: Optional[str],


### PR DESCRIPTION
## Summary
- Restrict MAS authorized users to Morgan and RJ.
- Add factual incident-chain verification and BFF attribution support.
- Add fail-closed Guardian command and red-team scenario contracts.

## Validation
- Python syntax compilation passed with Python 3.12.
- IDE diagnostics report no errors in changed modules.
- Poetry Ruff could not run because the checked-in virtual environment references a missing Python 3.13 interpreter.

## Safety
- Legacy synthetic red-team simulator endpoints are disabled by default.
- New unavailable contracts execute no command and create no artificial SOC data.

## Summary by Sourcery

Introduce CMMC posture integrity monitoring, factual incident-chain verification, and safer SOC command/red-team contracts while tightening security posture and documentation.

New Features:
- Add global incident-chain verification API and hash-chain integrity reporting.
- Expose a read-only CMMC posture integrity health endpoint and integrate posture validation into compliance controls and score APIs.
- Introduce Guardian command request/decision contracts that accept SOC actions without directly executing operations.
- Add red-team scenario registry and scenario-run request contracts that are intentionally unavailable until durable ledgers exist.

Bug Fixes:
- Prevent empty or anomalous compliance control results from being represented as zero-Met posture, treating them as availability incidents instead.

Enhancements:
- Gate legacy synthetic red-team simulation endpoints behind an explicit isolation flag and fail closed by default.
- Capture reporter and actor metadata into incident details and timelines to improve factual attribution.
- Persist and reuse a last-known-good CMMC posture snapshot via a MAS-resident monitor with optional Redis backing.
- Extend documentation with defense license/CI handoff and CMMC posture integrity/zero-flash design notes.

Deployment:
- Wire the posture integrity monitor into MAS startup/shutdown lifecycle and mount the new posture integrity router in the main API app.

Documentation:
- Add defense license and CI handoff documentation clarifying scope, execution, and public repo decisions.
- Document the CMMC posture UI zero-flash fix and MAS-based posture integrity guard.
- Record the amended Cursor handoff for defense licensing and CI behavior.

Chores:
- Update Cursor docs index and security configuration metadata to reflect new CMMC Wave 1 artifacts and authorization rules.
- Register Morgan as sole GitHub approver via Cursor rules metadata.