### PR TITLE
fix(guardian): fail closed on API key store errors

### DIFF
--- a/mycosoft_mas/core/routers/api_keys.py
+++ b/mycosoft_mas/core/routers/api_keys.py
@@ -1,12 +1,14 @@
 """API key management for MYCA services."""
 
 import hashlib
+import logging
 import secrets
 import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+import asyncpg
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
@@ -14,6 +16,7 @@ from mycosoft_mas.core.security import get_current_user
 from mycosoft_mas.integrations.mindex_client import MINDEXClient
 
 router = APIRouter(prefix="/api/keys", tags=["api-keys"])
+logger = logging.getLogger(__name__)
 _mindex_client = MINDEXClient()
 _rate_windows: dict[str, list[float]] = {}
 _rate_window_seconds = 60
@@ -98,18 +101,34 @@ async def require_api_key(request: Request) -> Dict[str, Any]:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="X-API-Key header missing",
         )
-    await _ensure_api_keys_table()
-    key_hash = _hash_key(raw_key)
-    pool = await _mindex_client._get_db_pool()
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            SELECT id, user_id, scopes, rate_limit, created_at, expires_at
-            FROM api_keys
-            WHERE key_hash = $1
-            """,
-            key_hash,
+    try:
+        await _ensure_api_keys_table()
+        key_hash = _hash_key(raw_key)
+        pool = await _mindex_client._get_db_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT id, user_id, scopes, rate_limit, created_at, expires_at
+                FROM api_keys
+                WHERE key_hash = $1
+                """,
+                key_hash,
+            )
+    except (
+        asyncpg.PostgresError,
+        ConnectionError,
+        OSError,
+        TimeoutError,
+        ValueError,
+    ) as error:
+        logger.warning(
+            "API key credential store unavailable: %s",
+            type(error).__name__,
         )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="API key authentication is temporarily unavailable",
+        ) from error
     if not row:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/tests/core/test_api_key_auth.py
+++ b/tests/core/test_api_key_auth.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncpg
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from mycosoft_mas.core.routers import api_keys
+
+
+def _request(api_key: str | None = None) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if api_key:
+        headers.append((b"x-api-key", api_key.encode("utf-8")))
+    return Request({"type": "http", "headers": headers})
+
+
+def _pool_with_row(row: dict[str, object] | None) -> MagicMock:
+    connection = AsyncMock()
+    connection.fetchrow.return_value = row
+    acquired_connection = MagicMock()
+    acquired_connection.__aenter__ = AsyncMock(return_value=connection)
+    acquired_connection.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire.return_value = acquired_connection
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_rejects_missing_header() -> None:
+    with pytest.raises(HTTPException) as exception_info:
+        await api_keys.require_api_key(_request())
+
+    assert exception_info.value.status_code == 401
+    assert exception_info.value.detail == "X-API-Key header missing"
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_fails_closed_when_store_rejects_credentials() -> None:
+    with patch.object(
+        api_keys,
+        "_ensure_api_keys_table",
+        AsyncMock(side_effect=asyncpg.InvalidPasswordError("redacted")),
+    ):
+        with pytest.raises(HTTPException) as exception_info:
+            await api_keys.require_api_key(_request("test-key"))
+
+    assert exception_info.value.status_code == 503
+    assert exception_info.value.detail == "API key authentication is temporarily unavailable"
+    assert "redacted" not in exception_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_rejects_unknown_key() -> None:
+    pool = _pool_with_row(None)
+
+    with (
+        patch.object(api_keys, "_ensure_api_keys_table", AsyncMock()),
+        patch.object(api_keys._mindex_client, "_get_db_pool", AsyncMock(return_value=pool)),
+    ):
+        with pytest.raises(HTTPException) as exception_info:
+            await api_keys.require_api_key(_request("unknown-key"))
+
+    assert exception_info.value.status_code == 401
+    assert exception_info.value.detail == "Invalid API key"
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_accepts_valid_key() -> None:
+    record = {
+        "id": uuid.uuid4(),
+        "user_id": "guardian-operator",
+        "scopes": ["guardian:admin"],
+        "rate_limit": 10,
+        "created_at": None,
+        "expires_at": None,
+    }
+    pool = _pool_with_row(record)
+
+    with (
+        patch.object(api_keys, "_ensure_api_keys_table", AsyncMock()),
+        patch.object(api_keys._mindex_client, "_get_db_pool", AsyncMock(return_value=pool)),
+    ):
+        authenticated_record = await api_keys.require_api_key(_request("valid-key"))
+
+    assert authenticated_record == record
+
+
+@pytest.mark.asyncio
+async def test_scoped_key_rejects_missing_scope() -> None:
+    dependency = api_keys.require_api_key_scoped("guardian:admin").dependency
+    assert dependency is not None
+
+    with patch.object(
+        api_keys,
+        "require_api_key",
+        AsyncMock(return_value={"scopes": ["guardian:read"]}),
+    ):
+        with pytest.raises(HTTPException) as exception_info:
+            await dependency(_request("test-key"))
+
+    assert exception_info.value.status_code == 403
+    assert exception_info.value.detail == "Scope 'guardian:admin' required"
+
+
+@pytest.mark.asyncio
+async def test_scoped_key_accepts_required_scope() -> None:
+    dependency = api_keys.require_api_key_scoped("guardian:admin").dependency
+    assert dependency is not None
+    record = {"id": "key-id", "scopes": ["guardian:admin"]}
+
+    with patch.object(
+        api_keys,
+        "require_api_key",
+        AsyncMock(return_value=record),
+    ):
+        result = await dependency(_request("test-key"))
+
+    assert result == record


### PR DESCRIPTION
## Summary
- return a non-leaking fail-closed 503 when API-key credential storage is unavailable
- preserve 401 for missing/invalid keys and 403 for missing scopes
- add focused Guardian API-key dependency regression tests

## Validation
- `python -m pytest tests/core/test_api_key_auth.py -q`
- `python -m compileall -q mycosoft_mas/core/routers/api_keys.py tests/core/test_api_key_auth.py`

## Deployment notes
- `MAS_SKIP_BACKGROUND_STARTUP=1` remains unchanged.
- MAS 188 database configuration is readable and its configured `DATABASE_URL` connects successfully when tested with the service virtualenv.

## Summary by Sourcery

Introduce a CMMC posture integrity monitor, wire it into compliance APIs and startup/shutdown lifecycle, and harden API key authentication to fail closed on credential store errors.

New Features:
- Add a MAS-resident CMMC posture integrity monitor that validates compliance controls, maintains a last-known-good snapshot, and optionally persists it in Redis.
- Expose posture monitor health via a new `/api/security/posture-integrity` endpoint and include integrity metadata in `/api/compliance/controls` and `/api/compliance/score` responses.

Bug Fixes:
- Ensure API key authentication returns a non-leaking 503 Service Unavailable response when the credential store or database access fails instead of treating it as a missing key.
- Treat empty or malformed compliance control results and sudden zero-Met regressions as availability incidents, returning 503 or degraded snapshots rather than a fabricated zero-compliance posture.

Enhancements:
- Integrate the posture integrity monitor into the FastAPI app lifecycle with startup and shutdown hooks for periodic validation and clean shutdown logging.
- Augment compliance API responses with verified practice counts and derived percentages based on the canonical 110-practice CMMC model.

Documentation:
- Add CMMC posture "zero-flash" fix documentation describing the monitor, degraded API behavior, and UI expectations.
- Document the defense license and CI handoff, including license sweep, CI fixes, and public repo visibility decisions.
- Add Cursor handoff notes for the defense license and CI scope amendments.

Tests:
- Add focused Guardian API key dependency tests covering missing headers, store failures, unknown keys, and scope enforcement.