### PR TITLE
fix(mindex): preserve encoded database credentials

### DIFF
--- a/mycosoft_mas/integrations/mindex_client.py
+++ b/mycosoft_mas/integrations/mindex_client.py
@@ -108,38 +108,13 @@ class MINDEXClient:
             Pool is created on first access and reused for subsequent queries.
         """
         if self._db_pool is None:
-            # Parse connection string
-            conn_str = self.database_url.replace("postgresql://", "").replace("postgres://", "")
-            if "@" in conn_str:
-                auth, host_part = conn_str.split("@", 1)
-                user, password = auth.split(":", 1) if ":" in auth else (auth, "")
-                if "/" in host_part:
-                    host_port, database = host_part.rsplit("/", 1)
-                    host, port = host_port.split(":") if ":" in host_port else (host_port, "5432")
-                else:
-                    host, port = host_part.split(":") if ":" in host_part else (host_part, "5432")
-                    database = "mindex"
-            else:
-                # Fallback defaults
-                user, password, host, port, database = (
-                    "mindex",
-                    "mindex",
-                    "localhost",
-                    "5432",
-                    "mindex",
-                )
-
             self._db_pool = await asyncpg.create_pool(
-                host=host,
-                port=int(port),
-                user=user,
-                password=password,
-                database=database,
+                dsn=self.database_url,
                 min_size=2,
                 max_size=10,
                 command_timeout=self.timeout,
             )
-            self.logger.info(f"Created database connection pool to {host}:{port}/{database}")
+            self.logger.info("Created MINDEX database connection pool")
 
         return self._db_pool
 

--- a/tests/integrations/test_mindex_client.py
+++ b/tests/integrations/test_mindex_client.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mycosoft_mas.integrations.mindex_client import MINDEXClient
+
+
+@pytest.mark.asyncio
+async def test_database_pool_uses_raw_dsn_for_encoded_credentials() -> None:
+    database_url = "postgresql://mindex:password%3Awith%40symbols@db.example:5432/mindex"
+    client = MINDEXClient(config={"database_url": database_url})
+    pool = object()
+
+    with patch(
+        "mycosoft_mas.integrations.mindex_client.asyncpg.create_pool",
+        AsyncMock(return_value=pool),
+    ) as create_pool:
+        result = await client._get_db_pool()
+
+    assert result is pool
+    create_pool.assert_awaited_once_with(
+        dsn=database_url,
+        min_size=2,
+        max_size=10,
+        command_timeout=30,
+    )


### PR DESCRIPTION
## Summary
- pass `MINDEX_DATABASE_URL` directly to `asyncpg.create_pool`
- preserve percent-decoding for reserved characters in database credentials
- add a regression test for encoded DSNs

## Validation
- `python -m pytest tests/core/test_api_key_auth.py tests/integrations/test_mindex_client.py -q`
- `python -m compileall -q mycosoft_mas/core/routers/api_keys.py mycosoft_mas/integrations/mindex_client.py tests/core/test_api_key_auth.py tests/integrations/test_mindex_client.py`

## Safety
- No credential values are changed or exposed.
- This addresses the live `InvalidPasswordError` in Guardian scoped API-key validation.

## Summary by Sourcery

Use the raw MINDEX database URL DSN when creating the asyncpg connection pool to preserve encoded credentials and adjust logging accordingly.

Bug Fixes:
- Fix database pool creation so encoded credentials in MINDEX_DATABASE_URL are preserved when connecting.

Enhancements:
- Simplify MINDEX database pool initialization by delegating DSN parsing to asyncpg and making connection logging less verbose.

Tests:
- Add an integration test verifying that MINDEXClient passes the raw encoded DSN to asyncpg.create_pool when building the database pool.