### PR TITLE
Require evidence for implemented CMMC controls

### DIFF
--- a/mycosoft_mas/core/routers/compliance_api.py
+++ b/mycosoft_mas/core/routers/compliance_api.py
@@ -54,6 +54,10 @@ class DocRegenerateRequest(BaseModel):
     title: str = "Regenerated document"
 
 
+def _has_evidence_uri(evidence_uri: Optional[str]) -> bool:
+    return bool(evidence_uri and evidence_uri.strip())
+
+
 class BackgroundCheckOrderRequest(BaseModel):
     applicant_email: str = Field(min_length=3, max_length=254)
     report_sku: Literal["HIRE1", "HIRE2", "HIRE3"]
@@ -414,6 +418,13 @@ async def list_controls():
 async def upsert_control(body: ControlUpsert):
     if not _pg_ready():
         raise HTTPException(status_code=503, detail="MINDEX_DATABASE_URL not configured")
+    if body.implementation_state == "implemented" and not _has_evidence_uri(
+        body.evidence_uri
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="implemented controls require a non-empty evidence_uri",
+        )
     try:
         from mycosoft_mas.soc import repository as soc_repo
 

--- a/mycosoft_mas/security/posture_integrity_monitor.py
+++ b/mycosoft_mas/security/posture_integrity_monitor.py
@@ -53,6 +53,10 @@ def _status_rank(row: dict[str, Any]) -> int:
     return {"implemented": 3, "compliant": 3, "partial": 2}.get(status, 1)
 
 
+def _has_evidence_uri(row: dict[str, Any]) -> bool:
+    return bool(str(row.get("evidence_uri") or "").strip())
+
+
 def _snapshot_from_controls(
     controls: Iterable[dict[str, Any]],
 ) -> tuple[PostureSnapshot | None, str | None]:
@@ -67,6 +71,17 @@ def _snapshot_from_controls(
 
     if not unique:
         return None, "controls_empty"
+
+    missing_evidence = [
+        practice_id
+        for practice_id, row in unique.items()
+        if _status_rank(row) == 3 and not _has_evidence_uri(row)
+    ]
+    if missing_evidence:
+        return None, (
+            "implemented controls are missing evidence_uri: "
+            + ", ".join(sorted(missing_evidence))
+        )
 
     met = sum(_status_rank(row) == 3 for row in unique.values())
     partial = sum(_status_rank(row) == 2 for row in unique.values())

--- a/tests/security/test_posture_evidence_integrity.py
+++ b/tests/security/test_posture_evidence_integrity.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from mycosoft_mas.core.routers.compliance_api import ControlUpsert, upsert_control
+from mycosoft_mas.security.posture_integrity_monitor import _snapshot_from_controls
+
+
+def test_posture_snapshot_rejects_implemented_control_without_evidence() -> None:
+    controls = [
+        {
+            "control_id": "IR.L2-3.6.3",
+            "implementation_state": "implemented",
+            "evidence_uri": "",
+        }
+    ]
+
+    snapshot, reason = _snapshot_from_controls(controls)
+
+    assert snapshot is None
+    assert reason is not None
+    assert "evidence_uri" in reason
+
+
+@pytest.mark.asyncio
+async def test_implemented_control_requires_evidence_uri(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MINDEX_DATABASE_URL", "postgresql://configured")
+
+    with pytest.raises(HTTPException) as exception_info:
+        await upsert_control(
+            ControlUpsert(
+                control_id="IR.L2-3.6.3",
+                implementation_state="implemented",
+            )
+        )
+
+    assert exception_info.value.status_code == 422
+    assert exception_info.value.detail == "implemented controls require a non-empty evidence_uri"


### PR DESCRIPTION
## Summary
- reject implemented compliance controls without a non-empty evidence URI
- invalidate posture snapshots that would count unsupported controls as Met
- add focused evidence-integrity regression coverage

## Test plan
- [x] `python -m pytest tests/security/test_posture_evidence_integrity.py -q` (with repository root on `PYTHONPATH`)

## Summary by Sourcery

Enforce evidence URI presence for implemented compliance controls and ensure posture snapshots and APIs treat controls without evidence as invalid.

Bug Fixes:
- Prevent posture snapshots from marking implemented controls as Met when they lack supporting evidence URIs.

Enhancements:
- Add validation in the compliance control upsert API to reject implemented controls that do not provide a non-empty evidence URI.

Tests:
- Introduce regression tests covering posture snapshot rejection of evidence-less implemented controls and API validation for evidence URI requirements.