### PR TITLE
feat(security): add Google Workspace boundary scanner

### DIFF
--- a/deploy/systemd/mycosoft-gws-boundary-scan.service
+++ b/deploy/systemd/mycosoft-gws-boundary-scan.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Mycosoft Google Workspace CUI boundary scan
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=mycosoft
+WorkingDirectory=/home/mycosoft/mycosoft/mas
+EnvironmentFile=-/home/mycosoft/mycosoft/mas/.env
+ExecStart=/home/mycosoft/.local/bin/poetry run python -m mycosoft_mas.soc.gws_boundary_worker
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/home/mycosoft/mycosoft/mas

--- a/deploy/systemd/mycosoft-gws-boundary-scan.timer
+++ b/deploy/systemd/mycosoft-gws-boundary-scan.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily Mycosoft Google Workspace CUI boundary scan
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=15m
+Persistent=true
+Unit=mycosoft-gws-boundary-scan.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/API_CATALOG_FEB04_2026.md
+++ b/docs/API_CATALOG_FEB04_2026.md
@@ -33,6 +33,15 @@ This document catalogs all API endpoints across the Mycosoft ecosystem. The regi
 
 **Routers:** `mycosoft_mas/core/routers/incidents_api.py`, `mycosoft_mas/core/routers/redteam_api.py`, compliance router (see `myca_main.py` includes). **Persistence:** MINDEX Postgres schema `soc_ops` (migrations in MINDEX repo). **Stream:** `mycosoft_mas/soc/security_events_stream.py` → Redis `security:events` (env `SOC_SECURITY_EVENTS_STREAM`). **Pollers:** `mycosoft_mas/soc/incident_source_poller.py`; **L2/L3:** `mycosoft_mas/redteam/layer2_scoped.py`, `layer3_ai.py`.
 
+### Google Workspace CUI-boundary scan (July 24, 2026)
+
+**Router:** `mycosoft_mas/core/routers/gws_boundary_api.py`. **Worker:** `mycosoft_mas/soc/gws_boundary_scan.py` and independent `mycosoft-gws-boundary-scan.timer`. **Persistence:** `soc_ops.gws_boundary_scan_runs` and `soc_ops.gws_boundary_scan_hits`. Results contain location metadata only; no Workspace content, filename, subject, or snippet is returned.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/security/gws-boundary/health` | GET | Configuration and safe worker status |
+| `/api/security/gws-boundary/status` | GET | `{ configured, last_run, status, scanned_scope, hit_count, hits[] }`; hits are location metadata only |
+
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/incidents/health` | GET | `{ ok, postgres_configured }` |

--- a/docs/GWS_BOUNDARY_SCAN_BACKEND_COMPLETE_JUL24_2026.md
+++ b/docs/GWS_BOUNDARY_SCAN_BACKEND_COMPLETE_JUL24_2026.md
@@ -1,0 +1,25 @@
+# Google Workspace Boundary Scan Backend Complete
+
+**Date:** July 24, 2026
+**Status:** Complete — credentials pending Morgan's Google Admin steps
+**Related:** `CODE/docs/CURSOR_GWS_BOUNDARY_SCAN_BACKEND_HANDOFF_JUL24_2026.md`
+
+## Delivered
+
+- MAS endpoint: `GET /api/security/gws-boundary/status`
+- Daily systemd timer independent of `MAS_SKIP_BACKGROUND_STARTUP`
+- Metadata-only persistence in `soc_ops.gws_boundary_scan_runs` and `soc_ops.gws_boundary_scan_hits`
+- Drive metadata scan with no body, snippet, filename, or subject persistence/exposure
+- Suspected-hit incident and critical SAO-notification wiring through existing SOC services
+- Focused missing-credential, sanitization, and fail-closed tests
+
+## Safety behavior
+
+The worker only exposes `{source, container, itemId, owner, markingToken, detectedAt}`. A hit opens a suspected-spillage incident and initiates SAO notification. Credential or API failure is reported as pending/error, never clean. No CMMC control status is changed by the worker.
+
+## Morgan actions still required
+
+1. Create the Google service account and key; enable the Admin SDK and Drive APIs.
+2. Authorize domain-wide delegation for Admin Reports read-only and Drive metadata read-only scopes.
+3. Set server-only `GOOGLE_WORKSPACE_ADMIN_EMAIL` and `GOOGLE_WORKSPACE_SA_KEY` on MAS 188. Do not put either value in git, a browser variable, or the public website.
+4. Explicitly approve any future Gmail or Sheets scope; neither is included in this deployment.

--- a/docs/MASTER_DOCUMENT_INDEX.md
+++ b/docs/MASTER_DOCUMENT_INDEX.md
@@ -1,5 +1,18 @@
 # Master Document Index
 
+## Google Workspace boundary scan (July 24, 2026)
+
+- `docs/GWS_BOUNDARY_SCAN_BACKEND_COMPLETE_JUL24_2026.md` — MAS metadata-only Drive boundary scanner, independent daily timer, SOC incident/SAO-notification wiring, API contract, and remaining Google Admin prerequisites.
+
+## CMMC Wave 1 + IR status (July 22, 2026)
+
+- `CODE/docs/CMMC_IR_L2_3_6_3_MET_JUL22_2026.md` — **IR evidence completion**: dual-signed DocuSign AAR, EV-IR-001 registration, evidence URI, and live-promotion verification.
+- `CODE/docs/cmmc_evidence/ir/EV-IR-3.6.3_TABLETOP_COMPLETION_STATUS_JUL22_2026.md` — **Authoritative IR status**: signed + registered + Met; canonical AAR and Certificate of Completion references.
+- `CODE/docs/cmmc_evidence/ir/EV-IR-3.6.3_RAPID_HITL_SCRIPT_JUL22_2026.md` — Morgan + RJ 10–15 min tabletop facilitation script.
+- `CODE/docs/CMMC_IR_TABLETOP_HITL_NEXT_JUL22_2026.md` — HITL → capture → merge → DocuSign next steps.
+- `CODE/docs/cmmc_evidence/ir/ev_ir_3_6_3_aar_FILLED_UNSIGNED_JUL22_2026.pdf` — Filled unsigned AAR (repo copy).
+- `CODE/docs/CURSOR_TO_PERPLEXITY_IR_AAR_HANDBACK_JUL22_2026.md` — **Superseded** for Part B (wait-on-Perplexity PDF); Wave 1 Part A still valid.
+
 ## Psathyrella backend architecture (June 25, 2026)
 
 - `docs/PSATHYRELLA_BACKEND_P0_P6_STATUS_JUN27_2026.md` — **P0–P6 master status**: Cursor lane software complete, phase table, demo vs pool wiring, verification curls, hardware-blocked items.

--- a/docs/SYSTEM_REGISTRY_FEB04_2026.md
+++ b/docs/SYSTEM_REGISTRY_FEB04_2026.md
@@ -15,6 +15,10 @@ The System Registry is a PostgreSQL-backed service that tracks all components of
 
 - **BackgroundChecks.com + MYCA posture (MAS compliance)** — `mycosoft_mas/integrations/backgroundchecks_client.py`; compliance router extensions in `mycosoft_mas/core/routers/compliance_api.py` (`GET /api/compliance/background-checks`, `POST /api/compliance/background-checks/order`, `GET /api/myca/posture`). Credentials via env only (`BACKGROUNDCHECKS_*`, `MYCA_POSTURE_API_KEY`, optional `PREVEIL_DRIVE_PATH`). Doc: `docs/BACKGROUNDCHECKS_PREVEIL_MYCA_INTEGRATION_JUL20_2026.md`. Deployed MAS VM 188 Jul 20, 2026.
 
+## Recent Updates (July 24, 2026)
+
+- **Google Workspace CUI-boundary scan** — MAS-only, least-privilege Drive metadata scanner at `mycosoft_mas/soc/gws_boundary_scan.py`, with independent daily systemd timer (`deploy/systemd/mycosoft-gws-boundary-scan.timer`) so recovery-mode `MAS_SKIP_BACKGROUND_STARTUP=1` remains unchanged. API: `GET /api/security/gws-boundary/status`. It persists only location metadata in `soc_ops.gws_boundary_scan_*`, opens a suspected-spillage incident, and requests critical SAO notification on a marking hit. No Drive/Gmail content, filename, subject, or snippet is retained or exposed. Requires Morgan's Google Admin provisioning before scans can run.
+
 ## Recent Updates (May 3, 2026)
 
 - **Security SOC (real `/security` stack)** — Postgres-backed SOC on MINDEX (`soc_ops.*`): incidents router `/api/incidents/*`, Redis stream `security:events`, incident source poller, network discovery → `device_inventory`, red team L1–L3 (`redteam/*`, `GET /api/redteam/soc-runs`, `soc-findings`), compliance control collector + doc engine. Website: `/security/redteam` SOC tab, `/security/compliance` MAS bundle tab, network/incidents pages wired to MAS BFF. Docs: `docs/SECURITY_REAL_SYSTEMS_REBUILD_MAY03_2026.md`, `docs/NETWORK_AUTO_DISCOVERY_MAY03_2026.md`, `docs/REDTEAM_THREE_LAYER_MAY03_2026.md`, `docs/COMPLIANCE_DOC_ENGINE_MAY03_2026.md`.

--- a/migrations/031_gws_boundary_scan_jul24_2026.sql
+++ b/migrations/031_gws_boundary_scan_jul24_2026.sql
@@ -1,0 +1,31 @@
+-- Google Workspace CUI-boundary scan state — metadata only.
+-- No file names, message subjects, bodies, snippets, or credentials are stored.
+
+CREATE TABLE IF NOT EXISTS soc_ops.gws_boundary_scan_runs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    status TEXT NOT NULL CHECK (status IN ('clean', 'hits', 'error')),
+    started_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ NOT NULL,
+    scanned_scope JSONB NOT NULL DEFAULT '[]'::jsonb,
+    hit_count INTEGER NOT NULL DEFAULT 0 CHECK (hit_count >= 0),
+    error_code TEXT,
+    notification_status TEXT NOT NULL DEFAULT 'not-required',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gws_boundary_scan_runs_completed
+    ON soc_ops.gws_boundary_scan_runs (completed_at DESC);
+
+CREATE TABLE IF NOT EXISTS soc_ops.gws_boundary_scan_hits (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id UUID NOT NULL REFERENCES soc_ops.gws_boundary_scan_runs(id) ON DELETE CASCADE,
+    source TEXT NOT NULL,
+    container TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    marking_token TEXT NOT NULL,
+    detected_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_gws_boundary_scan_hits_run
+    ON soc_ops.gws_boundary_scan_hits (run_id, detected_at DESC);

--- a/mycosoft_mas/core/myca_main.py
+++ b/mycosoft_mas/core/myca_main.py
@@ -90,6 +90,7 @@ from mycosoft_mas.core.routers.fusarium_api import router as fusarium_router
 from mycosoft_mas.core.routers.fusarium_platform_api import router as fusarium_platform_router
 from mycosoft_mas.core.routers.gap_api import router as gap_api_router
 from mycosoft_mas.core.routers.guardian_api import router as guardian_router
+from mycosoft_mas.core.routers.gws_boundary_api import router as gws_boundary_router
 from mycosoft_mas.core.routers.ingest_api import router as ingest_router
 from mycosoft_mas.core.routers.meshtastic_api import router as meshtastic_api_router
 from mycosoft_mas.core.routers.integrations import router as integrations_router
@@ -832,6 +833,7 @@ app.include_router(network_api_router, tags=["network"])
 app.include_router(memory_router, tags=["memory"])
 app.include_router(conversation_memory_router, tags=["memory", "myca-conversations"])
 app.include_router(security_router, tags=["security"])
+app.include_router(gws_boundary_router)
 app.include_router(guardian_router, tags=["guardian"])
 app.include_router(merkle_ledger_router, tags=["merkle-ledger"])
 app.include_router(event_ledger_router, tags=["event-ledger"])

--- a/mycosoft_mas/core/routers/gws_boundary_api.py
+++ b/mycosoft_mas/core/routers/gws_boundary_api.py
@@ -1,0 +1,27 @@
+"""Read-only status API for Google Workspace CUI-boundary scan results."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+from mycosoft_mas.soc.gws_boundary_scan import get_boundary_status
+
+router = APIRouter(prefix="/api/security/gws-boundary", tags=["security", "gws-boundary"])
+
+
+@router.get("/health")
+async def gws_boundary_health() -> dict[str, Any]:
+    status = await get_boundary_status()
+    return {
+        "ok": status["status"] not in {"error"},
+        "configured": status["configured"],
+        "status": status["status"],
+    }
+
+
+@router.get("/status")
+async def gws_boundary_status() -> dict[str, Any]:
+    """Return metadata-only scan state for the website BFF."""
+    return await get_boundary_status()

--- a/mycosoft_mas/soc/gws_boundary_scan.py
+++ b/mycosoft_mas/soc/gws_boundary_scan.py
@@ -1,0 +1,393 @@
+"""Google Workspace CUI-boundary scanner with metadata-only handling.
+
+Google Workspace is outside the CUI boundary. This worker detects marking
+tokens in Drive metadata and reduces every finding to an approved location
+record before persistence, notification, or API exposure.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DRIVE_METADATA_SCOPE = "https://www.googleapis.com/auth/drive.metadata.readonly"
+MARKING_TOKENS = (
+    "CONTROLLED UNCLASSIFIED",
+    "SP-CTI",
+    "SP-EXPT",
+    "SP-PROPIN",
+    "CUI//",
+    "EXPORT CONTROLLED",
+    "ITAR",
+    "CUI",
+)
+SCANNED_SCOPE = (
+    "Google Drive metadata (names, owners, identifiers, and modification timestamps only)"
+)
+DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _match_marking_token(value: str) -> str | None:
+    normalized = value.upper()
+    return next((token for token in MARKING_TOKENS if token in normalized), None)
+
+
+def sanitize_workspace_hit(
+    file_metadata: dict[str, Any],
+    *,
+    marking_token: str,
+    detected_at: str,
+) -> dict[str, str]:
+    """Return the only fields permitted beyond the scanner boundary."""
+    owners = file_metadata.get("owners")
+    first_owner = owners[0] if isinstance(owners, list) and owners else {}
+    owner = first_owner.get("emailAddress") if isinstance(first_owner, dict) else None
+
+    return {
+        "source": "google_drive",
+        "container": str(file_metadata.get("driveId") or "my-drive"),
+        "itemId": str(file_metadata.get("id") or ""),
+        "owner": str(owner or "unknown"),
+        "markingToken": marking_token,
+        "detectedAt": detected_at,
+    }
+
+
+class BoundaryScanService:
+    """Coordinates credential checks, Drive metadata scanning, and SOC escalation."""
+
+    def configuration_status(self) -> dict[str, Any]:
+        has_admin = bool((os.getenv("GOOGLE_WORKSPACE_ADMIN_EMAIL") or "").strip())
+        has_service_account = bool((os.getenv("GOOGLE_WORKSPACE_SA_KEY") or "").strip())
+        has_reports_token = bool((os.getenv("GOOGLE_WORKSPACE_REPORTS_TOKEN") or "").strip())
+        configured = has_admin and has_service_account
+
+        if configured:
+            return {
+                "configured": True,
+                "status": "configured-scan-pending",
+                "guidance": "Service-account credentials are configured; awaiting a verified metadata-only scan.",
+            }
+        if has_reports_token:
+            return {
+                "configured": True,
+                "status": "configured-scan-pending",
+                "guidance": (
+                    "Reports-token credentials are present, but Drive metadata scanning requires "
+                    "GOOGLE_WORKSPACE_ADMIN_EMAIL and GOOGLE_WORKSPACE_SA_KEY."
+                ),
+            }
+        return {
+            "configured": False,
+            "status": "not-configured",
+            "guidance": (
+                "Set GOOGLE_WORKSPACE_ADMIN_EMAIL and GOOGLE_WORKSPACE_SA_KEY after Morgan "
+                "completes Google Admin domain-wide delegation. No scan has run."
+            ),
+        }
+
+    async def run_once(self) -> dict[str, Any]:
+        configuration = self.configuration_status()
+        if not self._has_service_account_configuration():
+            return {
+                **configuration,
+                "last_run": None,
+                "scanned_scope": list(SCANNED_SCOPE),
+                "hit_count": 0,
+                "hits": [],
+            }
+
+        started_at = _utc_now()
+        try:
+            hits = await self._scan_drive_metadata()
+        except Exception as exc:  # noqa: BLE001
+            error_code = self._safe_error_code(exc)
+            logger.warning("Google Workspace boundary scan failed: %s", error_code)
+            await self._persist_run(
+                status="error",
+                started_at=started_at,
+                completed_at=_utc_now(),
+                hits=[],
+                error_code=error_code,
+                notification_status="not-required",
+            )
+            return {
+                "configured": True,
+                "status": "error",
+                "guidance": "The scan failed closed. Resolve the server-side credential or API configuration.",
+                "last_run": started_at,
+                "scanned_scope": list(SCANNED_SCOPE),
+                "hit_count": 0,
+                "hits": [],
+            }
+
+        completed_at = _utc_now()
+        notification_status = "not-required"
+        if hits:
+            notification_status = await self._escalate_hits(hits, completed_at)
+        status = "hits" if hits else "clean"
+        await self._persist_run(
+            status=status,
+            started_at=started_at,
+            completed_at=completed_at,
+            hits=hits,
+            error_code=None,
+            notification_status=notification_status,
+        )
+        return {
+            "configured": True,
+            "status": status,
+            "guidance": (
+                "Suspected spillage detected. Containment and SAO notification were initiated."
+                if hits
+                else "Verified metadata-only Drive scan completed with no marking-token matches."
+            ),
+            "last_run": completed_at,
+            "scanned_scope": list(SCANNED_SCOPE),
+            "hit_count": len(hits),
+            "hits": hits,
+        }
+
+    def _has_service_account_configuration(self) -> bool:
+        return bool(
+            (os.getenv("GOOGLE_WORKSPACE_ADMIN_EMAIL") or "").strip()
+            and (os.getenv("GOOGLE_WORKSPACE_SA_KEY") or "").strip()
+        )
+
+    async def _scan_drive_metadata(self) -> list[dict[str, str]]:
+        token = await self._get_service_account_token()
+        headers = {"Authorization": f"Bearer {token}"}
+        params: dict[str, Any] = {
+            "q": "trashed = false",
+            "pageSize": 100,
+            "fields": "nextPageToken,files(id,name,owners(emailAddress),modifiedTime,driveId)",
+            "supportsAllDrives": "true",
+            "includeItemsFromAllDrives": "true",
+        }
+        hits: list[dict[str, str]] = []
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            while True:
+                response = await client.get(DRIVE_FILES_URL, headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                for file_metadata in self._files_from_response(data):
+                    name = file_metadata.get("name")
+                    if not isinstance(name, str):
+                        continue
+                    marking_token = _match_marking_token(name)
+                    if marking_token:
+                        hits.append(
+                            sanitize_workspace_hit(
+                                file_metadata,
+                                marking_token=marking_token,
+                                detected_at=_utc_now(),
+                            )
+                        )
+                next_page = data.get("nextPageToken")
+                if not isinstance(next_page, str) or not next_page:
+                    break
+                params["pageToken"] = next_page
+        return hits
+
+    @staticmethod
+    def _files_from_response(data: Any) -> Iterable[dict[str, Any]]:
+        if not isinstance(data, dict):
+            return ()
+        files = data.get("files")
+        if not isinstance(files, list):
+            return ()
+        return (item for item in files if isinstance(item, dict))
+
+    async def _get_service_account_token(self) -> str:
+        key_data = self._load_service_account_key()
+        try:
+            from jose import jwt
+        except ImportError as exc:
+            raise RuntimeError("python-jose dependency is unavailable") from exc
+
+        token_uri = str(key_data.get("token_uri") or "https://oauth2.googleapis.com/token")
+        client_email = str(key_data.get("client_email") or "")
+        private_key = str(key_data.get("private_key") or "")
+        if not client_email or not private_key:
+            raise RuntimeError("service account key is missing signing fields")
+        issued_at = int(time.time())
+        assertion = jwt.encode(
+            {
+                "iss": client_email,
+                "sub": os.environ["GOOGLE_WORKSPACE_ADMIN_EMAIL"].strip(),
+                "aud": token_uri,
+                "scope": DRIVE_METADATA_SCOPE,
+                "iat": issued_at,
+                "exp": issued_at + 3600,
+            },
+            private_key,
+            algorithm="RS256",
+        )
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                token_uri,
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    "assertion": assertion,
+                },
+            )
+            response.raise_for_status()
+            response_data = response.json()
+        token = response_data.get("access_token") if isinstance(response_data, dict) else None
+        if not isinstance(token, str) or not token:
+            raise RuntimeError("service account did not return an access token")
+        return token
+
+    @staticmethod
+    def _load_service_account_key() -> dict[str, Any]:
+        raw_value = (os.getenv("GOOGLE_WORKSPACE_SA_KEY") or "").strip()
+        if not raw_value:
+            raise RuntimeError("service account key is unavailable")
+
+        key_path = Path(raw_value)
+        try:
+            raw_json = key_path.read_text(encoding="utf-8") if key_path.is_absolute() else ""
+        except OSError as exc:
+            raise RuntimeError("service account key path is unreadable") from exc
+
+        if not raw_json:
+            try:
+                raw_json = base64.b64decode(raw_value, validate=True).decode("utf-8")
+            except (binascii.Error, UnicodeDecodeError) as exc:
+                raise RuntimeError("service account key must be base64 JSON or an absolute path") from exc
+        try:
+            value = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("service account key JSON is invalid") from exc
+        if not isinstance(value, dict):
+            raise RuntimeError("service account key JSON must be an object")
+        return value
+
+    async def _escalate_hits(self, hits: list[dict[str, str]], detected_at: str) -> str:
+        notification_status = "sent"
+        try:
+            from mycosoft_mas.soc import repository as soc_repo
+
+            recent = await soc_repo.count_recent_incidents_by_source_kind(
+                "gws_boundary_scan",
+                "workspace_cui_marking",
+                within_minutes=60,
+            )
+            if recent == 0:
+                await soc_repo.create_incident(
+                    title="Suspected Google Workspace CUI-boundary spillage",
+                    description=(
+                        "A Workspace metadata marking match was detected. Contain the item and "
+                        "notify the SAO within one hour. This incident stores location metadata only."
+                    ),
+                    severity="high",
+                    status="investigating",
+                    source="gws_boundary_scan",
+                    kind="workspace_cui_marking",
+                    details={"hits": hits, "detected_at": detected_at},
+                    tags=["auto", "cui-boundary", "ir.l2-3.6"],
+                    timeline=[
+                        {
+                            "timestamp": detected_at,
+                            "action": "suspected_spillage_detected",
+                            "actor": "gws_boundary_scan",
+                            "details": "Location-only metadata captured; content was not retained.",
+                        }
+                    ],
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Unable to create GWS boundary incident: %s", self._safe_error_code(exc))
+
+        try:
+            from mycosoft_mas.services.admin_notifications import notify_morgan
+
+            result = await notify_morgan(
+                title="Suspected Google Workspace CUI-boundary spillage",
+                message=(
+                    "A metadata-only marking match was detected outside PreVeil. "
+                    "Contain the item and review the linked SOC incident within one hour."
+                ),
+                type="error",
+                agent="GoogleWorkspaceBoundaryScan",
+                priority="critical",
+                data={"hits": hits, "detected_at": detected_at},
+                requires_action=True,
+            )
+            if result.get("status") != "sent":
+                notification_status = "failed"
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Unable to notify SAO of boundary hit: %s", self._safe_error_code(exc))
+            notification_status = "failed"
+        return notification_status
+
+    async def _persist_run(
+        self,
+        *,
+        status: str,
+        started_at: str,
+        completed_at: str,
+        hits: list[dict[str, str]],
+        error_code: str | None,
+        notification_status: str,
+    ) -> None:
+        try:
+            from mycosoft_mas.soc import repository as soc_repo
+
+            await soc_repo.create_gws_boundary_scan_run(
+                status=status,
+                started_at=started_at,
+                completed_at=completed_at,
+                scanned_scope=list(SCANNED_SCOPE),
+                hits=hits,
+                error_code=error_code,
+                notification_status=notification_status,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Unable to persist GWS boundary scan state: %s", self._safe_error_code(exc))
+
+    @staticmethod
+    def _safe_error_code(exc: Exception) -> str:
+        if isinstance(exc, httpx.HTTPStatusError):
+            return f"http_{exc.response.status_code}"
+        if isinstance(exc, httpx.HTTPError):
+            return "http_error"
+        if isinstance(exc, RuntimeError):
+            return "configuration_error"
+        return "scan_error"
+
+
+async def get_boundary_status() -> dict[str, Any]:
+    """Return persisted status when available, otherwise an honest configuration state."""
+    service = BoundaryScanService()
+    configuration = service.configuration_status()
+    try:
+        from mycosoft_mas.soc import repository as soc_repo
+
+        latest = await soc_repo.get_latest_gws_boundary_scan_run()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Unable to read GWS boundary scan state: %s", service._safe_error_code(exc))
+        latest = None
+    if latest:
+        return {**configuration, **latest}
+    return {
+        **configuration,
+        "last_run": None,
+        "scanned_scope": list(SCANNED_SCOPE),
+        "hit_count": 0,
+        "hits": [],
+    }

--- a/mycosoft_mas/soc/gws_boundary_scan.py
+++ b/mycosoft_mas/soc/gws_boundary_scan.py
@@ -33,7 +33,7 @@ MARKING_TOKENS = (
     "CUI",
 )
 SCANNED_SCOPE = (
-    "Google Drive metadata (names, owners, identifiers, and modification timestamps only)"
+    "Google Drive metadata (names, owners, identifiers, and modification timestamps only)",
 )
 DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files"
 

--- a/mycosoft_mas/soc/gws_boundary_worker.py
+++ b/mycosoft_mas/soc/gws_boundary_worker.py
@@ -1,0 +1,22 @@
+"""One-shot entry point for the independently scheduled boundary scan."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from mycosoft_mas.soc.gws_boundary_scan import BoundaryScanService
+
+
+async def main() -> None:
+    result = await BoundaryScanService().run_once()
+    logging.getLogger(__name__).info(
+        "Google Workspace boundary scan completed: status=%s hit_count=%s",
+        result["status"],
+        result["hit_count"],
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/mycosoft_mas/soc/repository.py
+++ b/mycosoft_mas/soc/repository.py
@@ -828,7 +828,10 @@ async def compliance_score() -> Dict[str, Any]:
             """
             SELECT
               COUNT(*)::int AS total,
-              COUNT(*) FILTER (WHERE implementation_state = 'implemented')::int AS implemented,
+              COUNT(*) FILTER (
+                WHERE implementation_state = 'implemented'
+                  AND NULLIF(BTRIM(evidence_uri), '') IS NOT NULL
+              )::int AS implemented,
               COUNT(*) FILTER (WHERE implementation_state = 'partial')::int AS partial
             FROM soc_ops.compliance_controls
             """
@@ -966,3 +969,95 @@ async def insert_compliance_audit_log(
             json.dumps(payload),
         )
     return int(row["id"])
+
+
+async def create_gws_boundary_scan_run(
+    *,
+    status: str,
+    started_at: str,
+    completed_at: str,
+    scanned_scope: List[str],
+    hits: List[Dict[str, str]],
+    error_code: Optional[str],
+    notification_status: str,
+) -> Dict[str, Any]:
+    """Persist an approved-metadata-only Google Workspace boundary scan."""
+    pool = await _pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO soc_ops.gws_boundary_scan_runs
+                (status, started_at, completed_at, scanned_scope, hit_count, error_code, notification_status)
+            VALUES ($1, $2::timestamptz, $3::timestamptz, $4::jsonb, $5, $6, $7)
+            RETURNING id
+            """,
+            status,
+            started_at,
+            completed_at,
+            json.dumps(scanned_scope),
+            len(hits),
+            error_code,
+            notification_status,
+        )
+        run_id = row["id"]
+        for hit in hits:
+            await conn.execute(
+                """
+                INSERT INTO soc_ops.gws_boundary_scan_hits
+                    (run_id, source, container, item_id, owner, marking_token, detected_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7::timestamptz)
+                """,
+                run_id,
+                hit["source"],
+                hit["container"],
+                hit["itemId"],
+                hit["owner"],
+                hit["markingToken"],
+                hit["detectedAt"],
+            )
+    return await get_latest_gws_boundary_scan_run() or {}
+
+
+async def get_latest_gws_boundary_scan_run() -> Optional[Dict[str, Any]]:
+    """Return the most recent boundary scan with location-only hit metadata."""
+    pool = await _pool()
+    async with pool.acquire() as conn:
+        run = await conn.fetchrow(
+            """
+            SELECT id, status, completed_at, scanned_scope, hit_count, error_code, notification_status
+            FROM soc_ops.gws_boundary_scan_runs
+            ORDER BY completed_at DESC
+            LIMIT 1
+            """
+        )
+        if not run:
+            return None
+        rows = await conn.fetch(
+            """
+            SELECT source, container, item_id, owner, marking_token, detected_at
+            FROM soc_ops.gws_boundary_scan_hits
+            WHERE run_id = $1
+            ORDER BY detected_at DESC
+            """,
+            run["id"],
+        )
+    scope = run["scanned_scope"]
+    return {
+        "last_run": run["completed_at"].isoformat() if run["completed_at"] else None,
+        "status": run["status"],
+        "scanned_scope": scope if isinstance(scope, list) else json.loads(scope or "[]"),
+        "hit_count": int(run["hit_count"] or 0),
+        "hits": [
+            {
+                "source": row["source"],
+                "container": row["container"],
+                "itemId": row["item_id"],
+                "owner": row["owner"],
+                "markingToken": row["marking_token"],
+                "detectedAt": row["detected_at"].isoformat() if row["detected_at"] else None,
+            }
+            for row in rows
+        ],
+        "error_code": run["error_code"],
+        "notification_status": run["notification_status"],
+    }

--- a/tests/soc/test_gws_boundary_scan.py
+++ b/tests/soc/test_gws_boundary_scan.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+
+from mycosoft_mas.core.routers.gws_boundary_api import gws_boundary_status
+from mycosoft_mas.soc.gws_boundary_scan import (
+    BoundaryScanService,
+    get_boundary_status,
+    sanitize_workspace_hit,
+)
+
+
+def test_status_is_not_configured_without_service_account_credentials(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("GOOGLE_WORKSPACE_ADMIN_EMAIL", raising=False)
+    monkeypatch.delenv("GOOGLE_WORKSPACE_SA_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_WORKSPACE_REPORTS_TOKEN", raising=False)
+
+    status = BoundaryScanService().configuration_status()
+
+    assert status["configured"] is False
+    assert status["status"] == "not-configured"
+
+
+@pytest.mark.asyncio
+async def test_persisted_status_falls_back_to_pending_without_database(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("GOOGLE_WORKSPACE_ADMIN_EMAIL", raising=False)
+    monkeypatch.delenv("GOOGLE_WORKSPACE_SA_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_WORKSPACE_REPORTS_TOKEN", raising=False)
+
+    status = await get_boundary_status()
+
+    assert status["configured"] is False
+    assert status["status"] == "not-configured"
+    assert status["hits"] == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_service_account_configuration_fails_closed(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("GOOGLE_WORKSPACE_ADMIN_EMAIL", "admin@example.com")
+    monkeypatch.setenv("GOOGLE_WORKSPACE_SA_KEY", "not-a-valid-service-account-key")
+
+    result = await BoundaryScanService().run_once()
+
+    assert result["configured"] is True
+    assert result["status"] == "error"
+    assert result["hits"] == []
+
+
+@pytest.mark.asyncio
+async def test_read_api_returns_location_only_pending_status(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("GOOGLE_WORKSPACE_ADMIN_EMAIL", raising=False)
+    monkeypatch.delenv("GOOGLE_WORKSPACE_SA_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_WORKSPACE_REPORTS_TOKEN", raising=False)
+
+    response = await gws_boundary_status()
+
+    assert response["status"] == "not-configured"
+    assert response["hits"] == []
+    assert "content" not in response
+    assert "snippet" not in response
+
+
+def test_workspace_hit_strips_unapproved_google_response_fields() -> None:
+    hit = sanitize_workspace_hit(
+        {
+            "id": "drive-file-123",
+            "name": "CUI//SP-CTI restricted engineering data",
+            "owners": [{"emailAddress": "owner@example.com"}],
+            "modifiedTime": "2026-07-24T12:00:00Z",
+            "webViewLink": "https://drive.example/file",
+            "description": "CUI content must never leave its approved boundary",
+            "contentHints": {"indexableText": "sensitive body content"},
+        },
+        marking_token="CUI//",
+        detected_at="2026-07-24T12:30:00Z",
+    )
+
+    assert hit == {
+        "source": "google_drive",
+        "container": "my-drive",
+        "itemId": "drive-file-123",
+        "owner": "owner@example.com",
+        "markingToken": "CUI//",
+        "detectedAt": "2026-07-24T12:30:00Z",
+    }

--- a/tests/soc/test_gws_boundary_scan.py
+++ b/tests/soc/test_gws_boundary_scan.py
@@ -36,6 +36,9 @@ async def test_persisted_status_falls_back_to_pending_without_database(
     assert status["configured"] is False
     assert status["status"] == "not-configured"
     assert status["hits"] == []
+    assert status["scanned_scope"] == [
+        "Google Drive metadata (names, owners, identifiers, and modification timestamps only)"
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a MAS-only, metadata-only Drive marking scanner and `/api/security/gws-boundary/status`
- persist allowed location fields only; open SOC incidents and trigger critical SAO notification for hits
- schedule the worker through an independent daily systemd timer without clearing `MAS_SKIP_BACKGROUND_STARTUP`

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 poetry run pytest -p pytest_asyncio.plugin tests/soc/test_gws_boundary_scan.py -q` (5 passed in the source worktree)
- [x] `poetry run ruff check ...` (source worktree)
- [ ] CI

## Safety
No credentials, bodies, snippets, filenames, or subjects are committed, persisted, logged, or returned. Google Admin provisioning remains Morgan-only.

## Summary by Sourcery

Introduce a Google Workspace metadata-only boundary scanner with persistence, SOC escalation, and read-only status APIs, wired into MAS and scheduled via an independent daily worker.

New Features:
- Add a Google Workspace Drive metadata-only boundary scan worker that detects CUI marking tokens and runs as an independently scheduled systemd job.
- Expose read-only health and status endpoints under `/api/security/gws-boundary/*` to surface configuration and last scan results to the MAS BFF.

Bug Fixes:
- Refine compliance control implementation counting to require non-empty evidence URIs before marking controls as implemented.

Enhancements:
- Persist Google Workspace boundary scan runs and location-only hit metadata in new `soc_ops.gws_boundary_scan_runs` and `soc_ops.gws_boundary_scan_hits` tables and repository helpers.
- Integrate Google Workspace boundary scan status into existing SOC incident and admin notification flows with fail-closed behavior on configuration or API errors.

Build:
- Add systemd service and timer definitions for the Google Workspace boundary scan worker to enable independent daily scheduling without changing `MAS_SKIP_BACKGROUND_STARTUP`.

Documentation:
- Document the Google Workspace boundary scan backend, safety behavior, required Google Admin provisioning, and register it in the master index, API catalog, and system registry.
- Add CMMC Wave 1 + IR status documents to the master document index.

Tests:
- Add focused unit and async tests covering configuration states, fail-closed behavior, API responses, and metadata sanitization for the Google Workspace boundary scanner.