### PR TITLE
fix(compliance): reconcile partial current-state mismatches

### DIFF
--- a/scripts/cmmc/reconcile_control_state_jul27_2026.py
+++ b/scripts/cmmc/reconcile_control_state_jul27_2026.py
@@ -55,7 +55,7 @@ def _is_stale_implemented_row(row: Dict[str, Any]) -> bool:
             current_state.get("notes", ""),
         )
     ).lower()
-    return current_implementation in {"planned", "not_met"} or "not met" in notes
+    return current_implementation != "implemented" or "not met" in notes
 
 
 def _reconciled_body(row: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
Include implemented rows whose published current state is partial in the Jul 27 reconciliation.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Correct stale-implemented-row detection so that controls with partial or any non-implemented current state are included in reconciliation.